### PR TITLE
Information Overlay

### DIFF
--- a/OMXPlayerSubtitles.h
+++ b/OMXPlayerSubtitles.h
@@ -38,7 +38,9 @@ public:
   OMXPlayerSubtitles& operator=(const OMXPlayerSubtitles&) = delete;
   OMXPlayerSubtitles() BOOST_NOEXCEPT;
   ~OMXPlayerSubtitles() BOOST_NOEXCEPT;
-  bool Open(size_t stream_count,
+  bool Open(bool has_subs,
+            bool info_enabled,
+            size_t stream_count,
             std::vector<Subtitle>&& external_subtitles,
             const std::string& font_path,
             const std::string& italic_font_path,
@@ -86,6 +88,8 @@ public:
 
   bool AddPacket(OMXPacket *pkt, size_t stream_index) BOOST_NOEXCEPT;
 
+  void ShowInfo(string info, int duration = 2000) BOOST_NOEXCEPT;
+
 private:
   struct Message {
     struct Stop {};
@@ -109,6 +113,11 @@ private:
     {
       bool value;
     };
+    struct ShowInfo
+    {
+      std::vector<std::string> text_lines;
+      int duration;
+    };
   };
 
   void Process();
@@ -129,8 +138,11 @@ private:
           Message::Push,
           Message::Seek,
           Message::SetPaused,
-          Message::SetDelay>                    m_mailbox;
+          Message::SetDelay,
+          Message::ShowInfo>                    m_mailbox;
   bool                                          m_paused;
+  bool                                          m_has_subs;
+  bool                                          m_info_enabled;
   bool                                          m_visible;
   bool                                          m_use_external_subtitles;
   size_t                                        m_active_index;


### PR DESCRIPTION
Addresses Issue https://github.com/popcornmix/omxplayer/issues/9.
### Overview
- Adds method: OMXPlayerSubtitles::ShowInfo(string info, int duration = 2000)
- A new argv flag (--no-info-overlay) disables showing the information.

Calling ShowInfo stops the subtitle rendering, displays the specified info string, and waits duration milliseconds before showing subtitles again.  If the current media has no subtitles, the ShowInfo method is the only method in the OMXPlayerSubtitles class that is allowed to be called.

Currently provides information messages when these are changed:
- Play/Pause
- Volume
- Seek / Chapter 
- Subtitle delay
- Audio Channel
### Symbols

Unicode characters are being used for the play and pause symbols.
### Issues

Any info displayed while the media is paused will not get removed from the screen.  i.e., if you press pause, then change the volume, the 'Volume: ' overlay will stay on the screen until play resumes.  This is because the OMXPlayerSubtitles class uses the media clock to determine when to change subtitles.
