### PR TITLE
Joystick support!

### DIFF
--- a/KeyConfig.h
+++ b/KeyConfig.h
@@ -1,5 +1,8 @@
 #include <map>
+#include <vector>
 #include <string>
+#include <sys/types.h>
+#include <linux/joystick.h>
 
 class KeyConfig{
 
@@ -30,12 +33,27 @@ class KeyConfig{
         ACTION_STEP
     };
 
-    #define KEY_LEFT 0x5b44
-    #define KEY_RIGHT 0x5b43
-    #define KEY_UP 0x5b41
-    #define KEY_DOWN 0x5b42
-    #define KEY_ESC 27
+    #define KEY_LEFT_HEX 0x5b44
+    #define KEY_RIGHT_HEX 0x5b43
+    #define KEY_UP_HEX 0x5b41
+    #define KEY_DOWN_HEX 0x5b42
+    #define KEY_ESC_HEX 27
 
-    static std::map<int, int> buildDefaultKeymap();
-    static std::map<int, int> parseConfigFile(std::string filepath);
+    KeyConfig();
+    KeyConfig(char*);
+
+    int getAction(int key);
+    int getAction(std::string joystick, struct js_event *jse);
+
+    std::vector<std::string> getJoysticks(){ return joysticks; }
+    int getNumJoysticks(){ return joysticks.size(); }
+
+  private:
+    std::map<int, int> keymap;
+    std::map<std::string, int> jsmap;
+    std::vector<std::string> joysticks;
+    int num_joysticks;
+
+    void buildDefaultKeymap();
+    void parseConfigFile(char* filepath);
 };

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ While playing you can use the following keys to control omxplayer:
 Key Config Syntax
 -----------------
 
-A key config file is a series of rules of the form [action]:[key]. Multiple keys can be bound
+A key config file is a series of rules of the form [action]:[key]. Keyboard input 
+is supported as well as input from multiple joysticks. Multiple keys can be bound
 to the same action, and comments are supported by adding a # in front of the line.
 The list of valid [action]s roughly corresponds to the list of default key bindings above and are:
 
@@ -146,6 +147,7 @@ The list of valid [action]s roughly corresponds to the list of default key bindi
     STEP
 
 Valid [key]s include all alpha-numeric characters and most symbols, as well as:
+
     left
     right
     up
@@ -153,8 +155,22 @@ Valid [key]s include all alpha-numeric characters and most symbols, as well as:
     esc
     hex [keycode]
 
+Joystick inputs are defined of the form:
+
+    js /path/to/js a[number][+-]
+    js /path/to/js b[number]
+
+Where /path/to/js is the path to the joystick (usually something like /dev/input/js0),
+a denotes an axis is being bound, b denotes a button being bound, [number] is the
+number of the joystick axis or button, and [+-] designates which direction (positive or
+negative) of motion on the axis will trigger the event. Joystick axis and button 
+numbers can easily be discovered by using jstest. You do not need to declare the
+joysticks anywhere in the file; the parser will build the list of joysticks
+from the ones it finds that have buttons/axes bound.
+
 For example:
 
+    #Keyboard bindings
     EXIT:esc
     PAUSE:p
     #Note that this next line has a space after the :
@@ -162,3 +178,9 @@ For example:
     REWIND:left
     SEEK_FORWARD_SMALL:hex 0x4f43
     EXIT:q
+
+    #Joystick bindings
+    SEEK_FORWARD_SMALL:js /dev/input/js0 a0+
+    SEEK_BACK_SMALL:js /dev/input/js0 a0-
+    EXIT:js /dev/input/js0 b6
+    PAUSE:js /dev/input/js1 b0


### PR DESCRIPTION
Hey all, I've added joystick support. You can now bind actions in a keyconfig file to one or more joysticks! All of the changes are explained in the commit comment and the changes to the readme, but I thought I'd highlight the most important one (binding joysticks in a key config) here.

The short version of it is to bind a joystick axis you use the following syntax:

```
ACTION:js /path/to/js a[number][+-]
```

and the following for a button:

```
ACTION:js /path/to/js b[number]
```

[number] is just the number of the axis or button (watch out, they can overlap! There can exist an axis 0 and a button 0), and [+-] indicates the direction of movement of the axis that should trigger the event. If a direction is missing, it won't work.

I've tested it a bit and it all looks okay, but I'd appreciate it if anyone else with a joystick handy could test it out too. Some cases that I've tested that work properly:
- Multiple joysticks
- No joysticks
- Binding the same action to keyboard and multiple joysticks
- Having multiple joysticks plugged in but only one (or none) defined.
- Having multiple joysticks defined in keyconfig but not all of them exist (i.e. some are unplugged). The joysticks that ARE plugged in work fine.

If you have any questions feel free to ask, or if you have any more edge cases you want me to try out let me know that too!
