### PR TITLE
Seamless looping

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Using OMXPlayer
               --live                    Set for live tv or vod type stream
               --layout                  Set output speaker layout (e.g. 5.1)
               --key-config <file>       Uses key bindings specified in <file> instead of the default
+              --loop                    Loop the feed
 
 For example:
 


### PR DESCRIPTION
I have had a stab at seamless looping for streams that can seek: at EOF, rewind the reader and continue to feed packets into the decoder, but with modified PTS/DTS.
