### PR TITLE
Fix DBus issues with the launcher script and fix LD_LIBRARY_PATH.

### DIFF
--- a/omxplayer
+++ b/omxplayer
@@ -25,9 +25,9 @@ else
 fi
 
 if [ -e /usr/lib/omxplayer ]; then
-  export LD_LIBRARY_PATH=/opt/vc/lib:/usr/lib/omxplayer:$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=/opt/vc/lib:/usr/lib/omxplayer:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 else
-  export LD_LIBRARY_PATH=$PWD/ffmpeg_compiled/usr/local/lib:/opt/vc/lib:$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=$PWD/ffmpeg_compiled/usr/local/lib:/opt/vc/lib:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 fi
 
 XRES=1920


### PR DESCRIPTION
7f93b61 Fixes DBus issues #59 and #97.
It's an adaptation of the fix proposed by fcarlier in #59.

0e965c1 Fixes an issue with LD_LIBRARY_PATH discovered by @popcornmix.
If you have a bad lib in the current directory it will be included if your LD_LIBRARY_PATH is empty.
This is because LD_LIBRARY_PATH currently resolves to "/opt/vc/lib:/usr/lib/omxplayer:" causing to include the current directory because it ends in ":". This fix avoids to include non-existing LD_LIBRARY_PATH env var.

This fixes are already working on the launcher script I use for my packages.
