### PR TITLE
Reduce CPU when idle

### DIFF
--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -587,6 +587,7 @@ int main(int argc, char *argv[])
   enum PCMLayout m_layout = PCM_LAYOUT_2_0;
   TV_DISPLAY_STATE_T   tv_state;
   double last_seek_pos = 0;
+  bool idle = false;
 
   const int font_opt        = 0x100;
   const int italic_font_opt = 0x201;
@@ -1386,11 +1387,15 @@ int main(int argc, char *argv[])
       case KeyConfig::ACTION_HIDE_VIDEO:
         m_player_video.Close();
         if (m_live)
+        {
           m_omx_reader.Close();
+          idle = true;
+        }
         break;
       case KeyConfig::ACTION_UNHIDE_VIDEO:
         if (m_live)
         {
+          idle = false;
           if(!m_omx_reader.Open(m_filename.c_str(), m_dump_format, true))
             goto do_exit;
         }
@@ -1414,6 +1419,12 @@ int main(int argc, char *argv[])
       default:
         break;
     }
+    }
+
+    if (idle)
+    {
+      usleep(10000);
+      continue;
     }
 
     if(m_seek_flush || m_incr != 0)


### PR DESCRIPTION
Introduced an idle flag that will bypass processing and invoke a sleep state in the main loop, if we know for sure that nothing needs to be done. Reduces CPU usage from ~3% to ~1.3% on hidevideo.
