### PR TITLE
Allow selection of video rendering layer

### DIFF
--- a/OMXPlayerSubtitles.cpp
+++ b/OMXPlayerSubtitles.cpp
@@ -62,6 +62,7 @@ bool OMXPlayerSubtitles::Open(size_t stream_count,
                               bool centered,
                               bool ghost_box,
                               unsigned int lines,
+                              int layer,
                               OMXClock* clock) BOOST_NOEXCEPT
 {
   assert(!m_open);
@@ -82,6 +83,7 @@ bool OMXPlayerSubtitles::Open(size_t stream_count,
   m_ghost_box = ghost_box;
   m_lines = lines;
   m_av_clock = clock;
+  m_layer = layer;
 
   if(!Create())
     return false;
@@ -149,7 +151,7 @@ RenderLoop(const string& font_path,
            unsigned int lines,
            OMXClock* clock)
 {
-  SubtitleRenderer renderer(1,
+  SubtitleRenderer renderer(m_layer,
                             font_path,
                             italic_font_path,
                             font_size,

--- a/OMXPlayerSubtitles.h
+++ b/OMXPlayerSubtitles.h
@@ -47,6 +47,7 @@ public:
             bool centered,
             bool ghost_box,
             unsigned int lines,
+            int layer,
             OMXClock* clock) BOOST_NOEXCEPT;
   void Close() BOOST_NOEXCEPT;
   void Flush() BOOST_NOEXCEPT;
@@ -161,6 +162,7 @@ private:
   bool                                          m_ghost_box;
   unsigned int                                  m_lines;
   OMXClock*                                     m_av_clock;
+  int                                           m_layer;
 
 #ifndef NDEBUG
   bool m_open;

--- a/OMXPlayerVideo.cpp
+++ b/OMXPlayerVideo.cpp
@@ -52,6 +52,7 @@ OMXPlayerVideo::OMXPlayerVideo()
   m_max_data_size = 10 * 1024 * 1024;
   m_fifo_size     = (float)80*1024*60 / (1024*1024);
   m_history_valid_pts = 0;
+  m_layer = 0;
 
   pthread_cond_init(&m_packet_cond, NULL);
   pthread_cond_init(&m_picture_cond, NULL);
@@ -108,7 +109,7 @@ void OMXPlayerVideo::UnLockSubtitles()
 }
 
 bool OMXPlayerVideo::Open(COMXStreamInfo &hints, OMXClock *av_clock, const CRect& DestRect, EDEINTERLACEMODE deinterlace, bool hdmi_clock_sync, bool use_thread,
-                             float display_aspect, float queue_size, float fifo_size)
+                             float display_aspect, int layer, float queue_size, float fifo_size)
 {
   if (!m_dllAvUtil.Load() || !m_dllAvCodec.Load() || !m_dllAvFormat.Load() || !av_clock)
     return false;
@@ -134,6 +135,7 @@ bool OMXPlayerVideo::Open(COMXStreamInfo &hints, OMXClock *av_clock, const CRect
   m_iSubtitleDelay = 0;
   m_pSubtitleCodec = NULL;
   m_DestRect    = DestRect;
+  m_layer       = layer;
   if (queue_size != 0.0)
     m_max_data_size = queue_size * 1024 * 1024;
   if (fifo_size != 0.0)
@@ -431,7 +433,7 @@ bool OMXPlayerVideo::OpenDecoder()
   m_frametime = (double)DVD_TIME_BASE / m_fps;
 
   m_decoder = new COMXVideo();
-  if(!m_decoder->Open(m_hints, m_av_clock, m_DestRect, m_display_aspect, m_Deinterlace, m_hdmi_clock_sync, m_fifo_size))
+  if(!m_decoder->Open(m_hints, m_av_clock, m_DestRect, m_display_aspect, m_Deinterlace, m_hdmi_clock_sync, m_layer, m_fifo_size))
   {
     CloseDecoder();
     return false;

--- a/OMXPlayerVideo.h
+++ b/OMXPlayerVideo.h
@@ -84,6 +84,7 @@ protected:
   double                    m_iSubtitleDelay;
   COMXOverlayCodec          *m_pSubtitleCodec;
   uint32_t                  m_history_valid_pts;
+  int                       m_layer;
 
   void Lock();
   void UnLock();
@@ -96,7 +97,7 @@ public:
   OMXPlayerVideo();
   ~OMXPlayerVideo();
   bool Open(COMXStreamInfo &hints, OMXClock *av_clock, const CRect& DestRect, EDEINTERLACEMODE deinterlace, bool hdmi_clock_sync, bool use_thread,
-                   float display_aspect, float queue_size, float fifo_size);
+                   float display_aspect, int layer, float queue_size, float fifo_size);
   bool Close();
   bool Decode(OMXPacket *pkt);
   void Process();

--- a/OMXVideo.h
+++ b/OMXVideo.h
@@ -55,7 +55,7 @@ public:
   // Required overrides
   bool SendDecoderConfig();
   bool NaluFormatStartCodes(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize);
-  bool Open(COMXStreamInfo &hints, OMXClock *clock, const CRect &m_DestRect, float display_aspect = 0.0f, EDEINTERLACEMODE deinterlace = VS_DEINTERLACEMODE_OFF, bool hdmi_clock_sync = false, float fifo_size = 0.0f);
+  bool Open(COMXStreamInfo &hints, OMXClock *clock, const CRect &m_DestRect, float display_aspect = 0.0f, EDEINTERLACEMODE deinterlace = VS_DEINTERLACEMODE_OFF, bool hdmi_clock_sync = false, int layer = 0, float fifo_size = 0.0f);
   bool PortSettingsChanged();
   void Close(void);
   unsigned int GetFreeSpace();
@@ -116,6 +116,7 @@ protected:
   OMX_DISPLAYTRANSFORMTYPE m_transform;
   bool              m_settings_changed;
   CCriticalSection  m_critSection;
+  int               m_layer;
 };
 
 #endif


### PR DESCRIPTION
Added --layer n to command line. This changes the video rendering layer to the selected value. The background layer, if turned on, is set to the selected value -1. The subtitle layer is set to the selected value +1.
