### PR TITLE
Extend DBUS to include video layer

### DIFF
--- a/KeyConfig.h
+++ b/KeyConfig.h
@@ -35,7 +35,8 @@ class KeyConfig
         ACTION_BLANK = 24,
         ACTION_MOVE_VIDEO = 27,
         ACTION_HIDE_VIDEO = 28,
-        ACTION_UNHIDE_VIDEO = 29
+        ACTION_UNHIDE_VIDEO = 29,
+        ACTION_LAYER_VIDEO = 30
     };
 
     #define KEY_LEFT 0x5b44

--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -407,6 +407,29 @@ OMXControlResult OMXControl::getEvent()
     dbus_respond_ok(m);
     return KeyConfig::ACTION_UNHIDE_VIDEO;
   }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "VideoLayer"))
+  {
+    DBusError error;
+    dbus_error_init(&error);
+
+    int64_t layer;
+    dbus_message_get_args(m, &error, DBUS_TYPE_INT64, &layer, DBUS_TYPE_INVALID);
+
+    // Make sure a value is sent for setting VideoLayer
+    if (dbus_error_is_set(&error))
+    {
+      CLog::Log(LOGWARNING, "VideoLayer D-Bus Error: %s", error.message );
+      dbus_error_free(&error);
+      dbus_respond_ok(m);
+      return KeyConfig::ACTION_BLANK;
+    }
+    else
+    {
+      dbus_respond_int64(m, layer);
+      // OMX_CONFIG_DISPLAYREGIONTYPE struct, layer element is 32bit signed.
+      return OMXControlResult(KeyConfig::ACTION_LAYER_VIDEO, (int32_t)layer);
+    }
+  }
   else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "ListAudio"))
   {
     int count = reader->AudioStreamCount();

--- a/dbuscontrol.sh
+++ b/dbuscontrol.sh
@@ -58,6 +58,10 @@ unhidevideo)
 	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:29 >/dev/null
 	;;
 
+setvideolayer)
+	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.VideoLayer int64:$2 >/dev/null
+	;;
+
 volumeup)
 	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:18 >/dev/null
 	;;
@@ -67,7 +71,7 @@ volumedown)
 	;;
 
 *)
-	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|setvideopos [x1 y1 x2 y2]" >&2
+	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|setvideopos [x1 y1 x2 y2]|setvideolay n" >&2
 	exit 1
 	;;
 esac


### PR DESCRIPTION
Added DBUS commands to control the video rendering layer, this is not supported with --blank enabled
