### PR TITLE
bugfix: prevent failing audio when using dbus hidevideo

### DIFF
--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1390,10 +1390,12 @@ int main(int argc, char *argv[])
         break;
       case KeyConfig::ACTION_MOVE_VIDEO:
         sscanf(result.getWinArg(), "%f %f %f %f", &DestRect.x1, &DestRect.y1, &DestRect.x2, &DestRect.y2);
+        m_has_video = true;
         m_new_win_pos = true;
         m_seek_flush = true;
         break;
       case KeyConfig::ACTION_HIDE_VIDEO:
+        m_has_video = false;
         m_player_video.Close();
         if (m_live)
         {
@@ -1402,6 +1404,7 @@ int main(int argc, char *argv[])
         }
         break;
       case KeyConfig::ACTION_UNHIDE_VIDEO:
+        m_has_video = true;
         if (m_live)
         {
           idle = false;


### PR DESCRIPTION
Audio fails after a few seconds when using dbus hidevideo. Setting m_has_video flag to the correct value fixes the problem.
