### PR TITLE
Speed up ffmpeg cloning.

### DIFF
--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -244,9 +244,8 @@ configure:
 clean:
 	@rm -rf ffmpeg
 
-checkout: 
-	git clone git://source.ffmpeg.org/ffmpeg ffmpeg; \
-	cd ffmpeg; git checkout n2.2
+checkout:
+	git clone git://source.ffmpeg.org/ffmpeg ffmpeg -b n2.2 --depth=1
 
 install:
 	cd ffmpeg; make -j9 DESTDIR="$(WORK)/ffmpeg_compiled" install


### PR DESCRIPTION
No need to do a full clone if we just want to compile ffmpeg.
It's a 7× speedup on my desktop, way more if you clone it from a Rpi.
