### PR TITLE
Fix stdin control in absence of dbus

### DIFF
--- a/Keyboard.h
+++ b/Keyboard.h
@@ -10,6 +10,7 @@
  protected:
   struct termios orig_termios;
   int orig_fl;
+  int m_action;
   DBusConnection *conn;
   std::map<int,int> m_keymap;
   std::string m_dbus_name;
@@ -21,6 +22,7 @@
   void setKeymap(std::map<int,int> keymap);
   void setDbusName(std::string dbus_name);
   void Sleep(unsigned int dwMilliSeconds);
+  int getEvent();
  private:
   void restore_term();
   void send_action(int action);

--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -52,8 +52,9 @@ OMXControl::~OMXControl()
     dbus_disconnect();
 }
 
-void OMXControl::init(OMXClock *m_av_clock, OMXPlayerAudio *m_player_audio, OMXPlayerSubtitles *m_player_subtitles, OMXReader *m_omx_reader, std::string& dbus_name)
+int OMXControl::init(OMXClock *m_av_clock, OMXPlayerAudio *m_player_audio, OMXPlayerSubtitles *m_player_subtitles, OMXReader *m_omx_reader, std::string& dbus_name)
 {
+  int ret = 0;
   clock     = m_av_clock;
   audio     = m_player_audio;
   subtitles = m_player_subtitles;
@@ -71,6 +72,7 @@ void OMXControl::init(OMXClock *m_av_clock, OMXPlayerAudio *m_player_audio, OMXP
     {
       CLog::Log(LOGWARNING, "DBus connection failed, alternate failed, will continue without DBus");
       dbus_disconnect();
+      ret = -1;
     } else {
       CLog::Log(LOGDEBUG, "DBus connection succeeded");
       dbus_threads_init_default();
@@ -81,6 +83,7 @@ void OMXControl::init(OMXClock *m_av_clock, OMXPlayerAudio *m_player_audio, OMXP
     CLog::Log(LOGDEBUG, "DBus connection succeeded");
     dbus_threads_init_default();
   }
+  return ret;
 }
 
 void OMXControl::dispatch()

--- a/OMXControl.h
+++ b/OMXControl.h
@@ -32,7 +32,7 @@ protected:
 public:
   OMXControl();
   ~OMXControl();
-  void init(OMXClock *m_av_clock, OMXPlayerAudio *m_player_audio, OMXPlayerSubtitles *m_player_subtitles, OMXReader *m_omx_reader, std::string& dbus_name);
+  int init(OMXClock *m_av_clock, OMXPlayerAudio *m_player_audio, OMXPlayerSubtitles *m_player_subtitles, OMXReader *m_omx_reader, std::string& dbus_name);
   OMXControlResult getEvent();
   void dispatch();
 private:

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1001,7 +1001,13 @@ int main(int argc, char *argv[])
     printf("Only %dM of gpu_mem is configured. Try running \"sudo raspi-config\" and ensure that \"memory_split\" has a value of %d or greater\n", gpu_mem, min_gpu_mem);
 
   m_av_clock = new OMXClock();
-  m_omxcontrol.init(m_av_clock, &m_player_audio, &m_player_subtitles, &m_omx_reader, m_dbus_name);
+  int control_err = m_omxcontrol.init(
+    m_av_clock,
+    &m_player_audio,
+    &m_player_subtitles,
+    &m_omx_reader,
+    m_dbus_name
+  );
   if (false == m_no_keys)
   {
     m_keyboard = new Keyboard();
@@ -1181,7 +1187,9 @@ int main(int argc, char *argv[])
     }
 
      if (update) {
-       OMXControlResult result = m_omxcontrol.getEvent();
+       OMXControlResult result = control_err
+                               ? (OMXControlResult)m_keyboard->getEvent()
+                               : m_omxcontrol.getEvent();
        double oldPos, newPos;
 
     switch(result.getKey())


### PR DESCRIPTION
## Rationale

No STDIN w/o DBUS seems to be a showstopper for a few people.

Allow keyboard control via STDIN even in absence of dbus. Very important for headless server Pis, used also as media centres. Quick merge and release would be greatly appreciated.
## Changes

Keyboard:
Keyboard reading fully functional even in absence of dbus.
Store last keystroke in member m_action.
New method getEvent() returns and clears it.

OMXControl:
init returns error code -1 if dbus connection fails.

omxplayer:
If OMXControl failed to connect to dbus, read keystrokes directly
from Keyboard::getEvent().

Fixes #62
Fixes #131
