### PR TITLE
Enable Opus internal audio decoder in ffmpeg

### DIFF
--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -243,6 +243,7 @@ configure:
 			--disable-decoder=bintext \
 			--disable-decoder=xbin \
 			--disable-decoder=idf \
+			--enable-decoder=opus \
 			--cross-prefix=$(HOST)-
 
 .PHONY : clean


### PR DESCRIPTION
Hi,

This patch enables Opus audio support in omxplayer. Actually, support gets enabled in the bundled ffmpeg, as there's no hardware openmax implementation of Opus yet. ;)

This has been tested with both a .opus file made by opusenc, and a matroska stream with an opus track.

Regards,
Vittorio G
