### PR TITLE
DBUS: add VideoStreamCount and Aspect dbus commands

### DIFF
--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -333,6 +333,34 @@ OMXControlResult OMXControl::getEvent()
     dbus_respond_int64(m, pos);
     return KeyConfig::ACTION_BLANK;
   }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Aspect"))
+  {
+    // Returns aspect ratio
+    double ratio = reader->GetAspectRatio();
+    dbus_respond_double(m, ratio);
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "VideoStreamCount"))
+  {
+    // Returns number of video streams
+    int64_t vcount = reader->VideoStreamCount();
+    dbus_respond_int64(m, vcount);
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "ResWidth"))
+  {
+    // Returns width of video
+    int64_t width = reader->GetWidth();
+    dbus_respond_int64(m, width);
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "ResHeight"))
+  {
+    // Returns height of video
+    int64_t height = reader->GetHeight();
+    dbus_respond_int64(m, height);
+    return KeyConfig::ACTION_BLANK;
+  }
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Duration"))
   {
     // Returns the duration in microseconds

--- a/OMXReader.cpp
+++ b/OMXReader.cpp
@@ -888,6 +888,9 @@ bool OMXReader::GetHints(AVStream *stream, COMXStreamInfo *hints)
     AVDictionaryEntry *rtag = m_dllAvUtil.av_dict_get(stream->metadata, "rotate", NULL, 0);
     if (rtag)
       hints->orientation = atoi(rtag->value);
+    m_aspect = hints->aspect;
+    m_width = hints->width;
+    m_height = hints->height;
   }
 
   return true;

--- a/OMXReader.h
+++ b/OMXReader.h
@@ -122,6 +122,9 @@ protected:
   int                       m_speed;
   unsigned int              m_program;
   pthread_mutex_t           m_lock;
+  double                    m_aspect;
+  int                       m_width;
+  int                       m_height;
   void Lock();
   void UnLock();
   bool SetActiveStreamInternal(OMXStreamType type, unsigned int index);
@@ -151,6 +154,9 @@ public:
   int  SubtitleStreamCount() { return m_subtitle_count; };
   bool SetActiveStream(OMXStreamType type, unsigned int index);
   int  GetChapterCount() { return m_chapter_count; };
+  double GetAspectRatio() { return m_aspect; };
+  int GetWidth() { return m_width; };
+  int GetHeight() { return m_height; };
   OMXChapter GetChapter(unsigned int chapter) { return m_chapters[(chapter > MAX_OMX_CHAPTERS) ? MAX_OMX_CHAPTERS : chapter]; };
   static void FreePacket(OMXPacket *pkt);
   static OMXPacket *AllocPacket(int size);


### PR DESCRIPTION
Streamlines omxplayer GUI wrappers by removing the need for a separate call to "omxplayer -i <filename>" to determine if file has video and, if it does, what the aspect ratio of the video is.
