### PR TITLE
Fix omxplayer on multi user envs.

### DIFF
--- a/omxplayer
+++ b/omxplayer
@@ -44,8 +44,8 @@ if [ -z $NOREFRESH ] || [ "$NOREFRESH" == "0" ]; then
 fi
 
 DBUS_CMD="dbus-daemon --fork --print-address 5 --print-pid 6 --session"
-OMXPLAYER_DBUS_ADDR="/tmp/omxplayerdbus"
-OMXPLAYER_DBUS_PID="/tmp/omxplayerdbus.pid"
+OMXPLAYER_DBUS_ADDR="/tmp/omxplayerdbus.${USER}"
+OMXPLAYER_DBUS_PID="/tmp/omxplayerdbus.${USER}.pid"
 
 if [ ! -s "$OMXPLAYER_DBUS_PID" ] || ! pgrep -f "$DBUS_CMD" -F "$OMXPLAYER_DBUS_PID" >/dev/null; then
 	#echo "starting dbus for the first time" >&2


### PR DESCRIPTION
An user reported me that if you launch omxplayer with user A and when it finish you launch again omxplayer but with user B you can't control it (play/pause/stop/...) because the dbus daemon and tmp files are owned by A.

This commit should fix but I can't test right now (probably can't test it for some weeks, so if you can check it would be nice).

Here an extract of the email I've received from the user:

```
I've run into a bug that has an easy workaround once I figured out
what was going on, but was vexing for a little while: if a user runs
omxplayer, the wrapper will create the files
/tmp/omxplayerdbus{,.pid}, owned by that user. Even after that
omxplayer is no longer running, as long as those files exist another
user cannot use omxplayer -- the player will start, but the controls
(play/pause/stop etc) won't work.
```
