### PR TITLE
Turn off xset screensaver and dpms (energy star) modes

### DIFF
--- a/omxplayer
+++ b/omxplayer
@@ -43,6 +43,11 @@ if [ -z $NOREFRESH ] || [ "$NOREFRESH" == "0" ]; then
     fi
 fi
 
+if [ ! -z $xset_bin ]; then
+$xset_bin -dpms
+$xset_bin s off
+fi
+
 DBUS_CMD="dbus-daemon --fork --print-address 5 --print-pid 6 --session"
 OMXPLAYER_DBUS_ADDR="/tmp/omxplayerdbus.${USER}"
 OMXPLAYER_DBUS_PID="/tmp/omxplayerdbus.${USER}.pid"
@@ -65,6 +70,11 @@ export DBUS_SESSION_BUS_ADDRESS
 export DBUS_SESSION_BUS_PID
 
 LD_LIBRARY_PATH="$OMXPLAYER_LIBS${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" $OMXPLAYER_BIN "$@"; true
+
+if [ ! -z $xset_bin ]; then
+$xset_bin +dpms
+$xset_bin s on
+fi
 
 if [ ! -z $NOREFRESH ] && [ "$NOREFRESH" == "1" ]; then
     exit 0


### PR DESCRIPTION
@popcornmix New rpi firmware disables omxplayer video and audio when xset screensaver turns on. Disable on omxplayer start, re-enable on exit.

I'm new to shell scripting so not exactly sure if this is the best way to do it, but it works. Feel free to reject if it's not up to scratch.
