### PR TITLE
Implement ShowSubtitles and HideSubtitles via keyboard and DBUS

### DIFF
--- a/KeyConfig.cpp
+++ b/KeyConfig.cpp
@@ -58,6 +58,10 @@ int convertStringToAction(string str_action)
         return KeyConfig::ACTION_SEEK_FORWARD_LARGE;
     if(str_action == "STEP")
         return KeyConfig::ACTION_STEP;
+    if(str_action == "SHOW_SUBTITLES")
+        return KeyConfig::ACTION_SHOW_SUBTITLES;
+    if(str_action == "HIDE_SUBTITLES")
+        return KeyConfig::ACTION_HIDE_SUBTITLES;
             
     return -1;
 }
@@ -122,6 +126,8 @@ map<int, int> KeyConfig::buildDefaultKeymap()
     keymap[KEY_DOWN] = ACTION_SEEK_BACK_LARGE;
     keymap[KEY_UP] = ACTION_SEEK_FORWARD_LARGE;
     keymap['v'] = ACTION_STEP;
+    keymap['w'] = ACTION_SHOW_SUBTITLES;
+    keymap['x'] = ACTION_HIDE_SUBTITLES;
 
     return keymap;
 }

--- a/KeyConfig.h
+++ b/KeyConfig.h
@@ -35,7 +35,9 @@ class KeyConfig
         ACTION_BLANK = 24,
         ACTION_MOVE_VIDEO = 27,
         ACTION_HIDE_VIDEO = 28,
-        ACTION_UNHIDE_VIDEO = 29
+        ACTION_UNHIDE_VIDEO = 29,
+        ACTION_HIDE_SUBTITLES = 30,
+	 ACTION_SHOW_SUBTITLES = 31
     };
 
     #define KEY_LEFT 0x5b44

--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -542,13 +542,13 @@ OMXControlResult OMXControl::getEvent()
   {
     subtitles->SetVisible(true);
     dbus_respond_ok(m);
-    return KeyConfig::ACTION_BLANK;
+    return KeyConfig::ACTION_SHOW_SUBTITLES;
   }
   else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "HideSubtitles"))
   {
     subtitles->SetVisible(false);
     dbus_respond_ok(m);
-    return KeyConfig::ACTION_BLANK;
+    return KeyConfig::ACTION_HIDE_SUBTITLES;
   }
   else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "Action"))
   {

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Key bindings to control omxplayer while playing:
     n           previous subtitle stream
     m           next subtitle stream
     s           toggle subtitles
+    w           show subtitles
+    x           hide subtitles
     d           decrease subtitle delay (- 250 ms)
     f           increase subtitle delay (+ 250 ms)
     q           exit omxplayer

--- a/dbuscontrol.sh
+++ b/dbuscontrol.sh
@@ -65,9 +65,21 @@ volumeup)
 volumedown)
 	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:17 >/dev/null
 	;;
+	
+togglesubtitles)
+	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:12 >/dev/null
+	;;
+	
+hidesubtitles)
+	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:30 >/dev/null
+	;;
+
+showsubtitles)
+	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:31 >/dev/null
+	;;
 
 *)
-	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|setvideopos [x1 y1 x2 y2]" >&2
+	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|togglesubtitles|hidesubtitles|showsubtitles|setvideopos [x1 y1 x2 y2]" >&2
 	exit 1
 	;;
 esac

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1304,6 +1304,20 @@ int main(int argc, char *argv[])
           PrintSubtitleInfo();
         }
         break;
+      case KeyConfig::ACTION_HIDE_SUBTITLES:
+        if(m_has_subtitle)
+        {
+          m_player_subtitles.SetVisible(false);
+          PrintSubtitleInfo();
+        }
+        break;
+      case KeyConfig::ACTION_SHOW_SUBTITLES:
+        if(m_has_subtitle)
+        {
+          m_player_subtitles.SetVisible(true);
+          PrintSubtitleInfo();
+        }
+        break;
       case KeyConfig::ACTION_DECREASE_SUBTITLE_DELAY:
         if(m_has_subtitle && m_player_subtitles.GetVisible())
         {


### PR DESCRIPTION
Press the 'w' key above the 's' key to Show Subtitles
Press the 'x' key above the 's' key to Hide Subtitles

Also implements ShowSubtitles and HideSubtitles via DBUS
Adds ToggleSubtitles to DBUS

ie dbuscontrol.sh ToggleSubtitles
ie dbuscontrol.sh HideSubtitles
ie dbuscontrol.sh ShowSubtitles

Useful for machine-to-machine control of subtitles via DBUS where there is a requirement to explicitly set subtitles to a known state rather than toggle between two states.
