### PR TITLE
Added --cookie and --user-agent switches

### DIFF
--- a/OMXReader.cpp
+++ b/OMXReader.cpp
@@ -134,7 +134,7 @@ static offset_t dvd_file_seek(void *h, offset_t pos, int whence)
     return pFile->Seek(pos, whence & ~AVSEEK_FORCE);
 }
 
-bool OMXReader::Open(std::string filename, bool dump_format, bool live /* =false */, float timeout /* = 0.0f */)
+bool OMXReader::Open(std::string filename, bool dump_format, bool live /* =false */, float timeout /* = 0.0f */, std::string cookie /* = "" */, std::string user_agent /* = "" */)
 {
   if (!m_dllAvUtil.Load() || !m_dllAvCodec.Load() || !m_dllAvFormat.Load())
     return false;
@@ -188,6 +188,14 @@ bool OMXReader::Open(std::string filename, bool dump_format, bool live /* =false
        m_filename.substr(0,7) == "sftp://" || m_filename.substr(0,6) == "smb://"))
     {
        av_dict_set(&d, "seekable", "1", 0);
+       if(!cookie.empty())
+       {
+          av_dict_set(&d, "cookies", cookie.c_str(), 0);
+       }
+       if(!user_agent.empty())
+       {
+          av_dict_set(&d, "user_agent", user_agent.c_str(), 0);
+       }
     }
     CLog::Log(LOGDEBUG, "COMXPlayer::OpenFile - avformat_open_input %s ", m_filename.c_str());
     result = m_dllAvFormat.avformat_open_input(&m_pFormatContext, m_filename.c_str(), iformat, &d);

--- a/OMXReader.h
+++ b/OMXReader.h
@@ -132,7 +132,7 @@ private:
 public:
   OMXReader();
   ~OMXReader();
-  bool Open(std::string filename, bool dump_format, bool live = false, float timeout = 0.0f);
+  bool Open(std::string filename, bool dump_format, bool live = false, float timeout = 0.0f, std::string cookie = "", std::string user_agent = "");
   void ClearStreams();
   bool Close();
   //void FlushRead();

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Usage: omxplayer [OPTIONS] [FILE]
         --key-config <file>     Uses key bindings in <file> instead of the default
         --layer n               Set video render layer number (higher numbers are on top)
         --display n             Set display to output to
+        --cookie "cookie"       Send specified cookie as part of HTTP requests
+        --user-agent "ua"       Send specified User-Agent as part of HTTP requests
 
 For example:
 

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -534,6 +534,8 @@ int main(int argc, char *argv[])
   TV_DISPLAY_STATE_T   tv_state;
   double last_seek_pos = 0;
   bool idle = false;
+  std::string            m_cookie              = "";
+  std::string            m_user_agent          = "";
 
   const int font_opt        = 0x100;
   const int italic_font_opt = 0x201;
@@ -567,6 +569,8 @@ int main(int argc, char *argv[])
   const int anaglyph_opt    = 0x20d;
   const int native_deinterlace_opt = 0x20e;
   const int display_opt     = 0x20f;
+  const int http_cookie_opt = 0x300;
+  const int http_user_agent_opt = 0x301;
 
   struct option longopts[] = {
     { "info",         no_argument,        NULL,          'i' },
@@ -620,6 +624,8 @@ int main(int argc, char *argv[])
     { "loop",         no_argument,        NULL,          loop_opt },
     { "layer",        required_argument,  NULL,          layer_opt },
     { "display",      required_argument,  NULL,          display_opt },
+    { "cookie",       required_argument,  NULL,          http_cookie_opt },
+    { "user-agent",   required_argument,  NULL,          http_user_agent_opt },
     { 0, 0, 0, 0 }
   };
 
@@ -838,6 +844,12 @@ int main(int argc, char *argv[])
       case display_opt:
         m_display = atoi(optarg);
         break;
+      case http_cookie_opt:
+        m_cookie = optarg;
+        break;
+      case http_user_agent_opt:
+        m_user_agent = optarg;
+        break;    
       case 0:
         break;
       case 'h':
@@ -959,7 +971,7 @@ int main(int argc, char *argv[])
 
   m_thread_player = true;
 
-  if(!m_omx_reader.Open(m_filename.c_str(), m_dump_format, m_live, m_timeout))
+  if(!m_omx_reader.Open(m_filename.c_str(), m_dump_format, m_live, m_timeout, m_cookie.c_str(), m_user_agent.c_str()))
     goto do_exit;
 
   if (m_dump_format_exit)


### PR DESCRIPTION
Hi popcornmix,

I'm not sure if these small changes are suitable for merging, but they were required for my use case: appropriate Cookie and User-Agent headers need to be set to access certain HLS media streams.

Thanks for all your hard work!

Cheers,
Samir
