### PR TITLE
Fix Cppcheck reported issues and revert video/audio player instantiation order

### DIFF
--- a/DynamicDll.cpp
+++ b/DynamicDll.cpp
@@ -28,11 +28,11 @@ DllDynamic::DllDynamic()
   m_DelayUnload=true;
 }
 
-DllDynamic::DllDynamic(const CStdString& strDllName)
-{
-  m_strDllName=strDllName;
-  m_dll=NULL;
-  m_DelayUnload=true;
+DllDynamic::DllDynamic(const CStdString& strDllName):
+m_strDllName(strDllName),
+m_dll(NULL),
+m_DelayUnload(true)
+{	
 }
 
 DllDynamic::~DllDynamic()

--- a/OMXClock.cpp
+++ b/OMXClock.cpp
@@ -125,11 +125,8 @@ bool OMXClock::OMXSetReferenceClock(bool has_audio, bool lock /* = true */)
 
 bool OMXClock::OMXInitialize()
 {
-  std::string componentName = "";
-
   m_pause       = false;
-
-  componentName = "OMX.broadcom.clock";
+  std::string componentName = "OMX.broadcom.clock";
   if(!m_omx_clock.Initialize((const std::string)componentName, OMX_IndexParamOtherInit))
     return false;
 

--- a/OMXCore.cpp
+++ b/OMXCore.cpp
@@ -961,7 +961,7 @@ OMX_ERRORTYPE COMXCoreComponent::WaitForEvent(OMX_EVENTTYPE eventType, long time
   add_timespecs(endtime, timeout);
   while(true) 
   {
-    for (std::vector<omx_event>::iterator it = m_omx_events.begin(); it != m_omx_events.end(); it++) 
+    for (std::vector<omx_event>::iterator it = m_omx_events.begin(); it != m_omx_events.end(); ++it) 
     {
       omx_event event = *it;
 
@@ -1030,7 +1030,7 @@ OMX_ERRORTYPE COMXCoreComponent::WaitForCommand(OMX_U32 command, OMX_U32 nData2,
   add_timespecs(endtime, timeout);
   while(true) 
   {
-    for (std::vector<omx_event>::iterator it = m_omx_events.begin(); it != m_omx_events.end(); it++) 
+    for (std::vector<omx_event>::iterator it = m_omx_events.begin(); it != m_omx_events.end(); ++it) 
     {
       omx_event event = *it;
 

--- a/OMXOverlayCodec.h
+++ b/OMXOverlayCodec.h
@@ -37,10 +37,9 @@ class COMXOverlayCodec
 {
 public:
 
-  COMXOverlayCodec(const char* name)
-  {
-    m_codecName = name;
-  }
+  COMXOverlayCodec(const char* name):
+  m_codecName(name)
+  {}
 
   virtual ~COMXOverlayCodec() {}
 

--- a/OMXOverlayText.h
+++ b/OMXOverlayText.h
@@ -38,7 +38,8 @@ public:
   class CElement
   {
   public:
-    CElement(ElementType type)
+    CElement(ElementType type):
+    pNext(NULL)
     {
       m_type = type;
     }
@@ -98,10 +99,10 @@ public:
 
   virtual ~COMXOverlayText()
   {
-    CElement* pTemp;
+    
     while (m_pHead)
     {
-      pTemp = m_pHead;
+      CElement* pTemp = m_pHead;
       m_pHead = m_pHead->pNext;
       delete pTemp;
     }

--- a/OMXPlayerAudio.cpp
+++ b/OMXPlayerAudio.cpp
@@ -32,27 +32,26 @@
 
 #include "linux/XMemUtils.h"
 
-OMXPlayerAudio::OMXPlayerAudio()
+OMXPlayerAudio::OMXPlayerAudio():
+  m_open(false),
+  m_stream_id(-1),
+  m_pStream(NULL),
+  m_av_clock(NULL),
+  m_omx_reader(NULL),
+  m_decoder(NULL),
+  m_flush(false),
+  m_flush_requested(false),
+  m_cached_size(0),
+  m_pAudioCodec(NULL),
+  m_player_error(true),
+  m_max_data_size(3 * 1024 * 1024),
+  m_fifo_size(2.0f),
+  m_live(false),
+  m_layout(PCM_LAYOUT_2_0),
+  m_CurrentVolume(0.0f),
+  m_amplification(0),
+  m_mute(false)
 {
-  m_open          = false;
-  m_stream_id     = -1;
-  m_pStream       = NULL;
-  m_av_clock      = NULL;
-  m_omx_reader    = NULL;
-  m_decoder       = NULL;
-  m_flush         = false;
-  m_flush_requested = false;
-  m_cached_size   = 0;
-  m_pAudioCodec   = NULL;
-  m_player_error  = true;
-  m_max_data_size = 3 * 1024 * 1024;
-  m_fifo_size     = 2.0f;
-  m_live          = false;
-  m_layout        = PCM_LAYOUT_2_0;
-  m_CurrentVolume = 0.0f;
-  m_amplification = 0;
-  m_mute          = false;
-
   pthread_cond_init(&m_packet_cond, NULL);
   pthread_cond_init(&m_audio_cond, NULL);
   pthread_mutex_init(&m_lock, NULL);

--- a/OMXPlayerAudio.h
+++ b/OMXPlayerAudio.h
@@ -56,7 +56,6 @@ protected:
   double                    m_iCurrentPts;
   pthread_cond_t            m_packet_cond;
   pthread_cond_t            m_audio_cond;
-  pthread_mutex_t           m_lock;
   pthread_mutex_t           m_lock_decoder;
   OMXClock                  *m_av_clock;
   OMXReader                 *m_omx_reader;

--- a/OMXPlayerVideo.cpp
+++ b/OMXPlayerVideo.cpp
@@ -33,7 +33,8 @@
 
 #include "linux/XMemUtils.h"
 
-OMXPlayerVideo::OMXPlayerVideo()
+OMXPlayerVideo::OMXPlayerVideo():
+m_flush_requested(false)
 {
   m_open          = false;
   m_stream_id     = -1;
@@ -42,7 +43,6 @@ OMXPlayerVideo::OMXPlayerVideo()
   m_decoder       = NULL;
   m_fps           = 25.0f;
   m_flush         = false;
-  m_flush_requested = false;
   m_cached_size   = 0;
   m_hdmi_clock_sync = false;
   m_iVideoDelay   = 0;

--- a/OMXPlayerVideo.h
+++ b/OMXPlayerVideo.h
@@ -54,7 +54,6 @@ protected:
   double                    m_iCurrentPts;
   pthread_cond_t            m_packet_cond;
   pthread_cond_t            m_picture_cond;
-  pthread_mutex_t           m_lock;
   pthread_mutex_t           m_lock_decoder;
   OMXClock                  *m_av_clock;
   COMXVideo                 *m_decoder;

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1020,6 +1020,33 @@ int main(int argc, char *argv[])
 
   if(m_audio_index_use > 0)
     m_omx_reader.SetActiveStream(OMXSTREAM_AUDIO, m_audio_index_use-1);
+  
+  if (deviceString == "")
+  {
+    if (m_BcmHost.vc_tv_hdmi_audio_supported(EDID_AudioFormat_ePCM, 2, EDID_AudioSampleRate_e44KHz, EDID_AudioSampleSize_16bit ) == 0)
+      deviceString = "omx:hdmi";
+    else
+      deviceString = "omx:local";
+  }
+
+  if ((m_hints_audio.codec == CODEC_ID_AC3 || m_hints_audio.codec == CODEC_ID_EAC3) &&
+      m_BcmHost.vc_tv_hdmi_audio_supported(EDID_AudioFormat_eAC3, 2, EDID_AudioSampleRate_e44KHz, EDID_AudioSampleSize_16bit ) != 0)
+    m_passthrough = false;
+  if (m_hints_audio.codec == CODEC_ID_DTS &&
+      m_BcmHost.vc_tv_hdmi_audio_supported(EDID_AudioFormat_eDTS, 2, EDID_AudioSampleRate_e44KHz, EDID_AudioSampleSize_16bit ) != 0)
+    m_passthrough = false;
+
+  if(m_has_audio && !m_player_audio.Open(m_hints_audio, m_av_clock, &m_omx_reader, deviceString, 
+                                         m_passthrough, m_use_hw_audio,
+                                         m_boost_on_downmix, m_thread_player, m_live, m_layout, audio_queue_size, audio_fifo_size))
+    goto do_exit;
+
+  if(m_has_audio)
+  {
+    m_player_audio.SetVolume(pow(10, m_Volume / 2000.0));
+    if (m_Amplification)
+      m_player_audio.SetDynamicRangeCompression(m_Amplification);
+  }
           
   if(m_has_video && m_refresh)
   {
@@ -1084,35 +1111,6 @@ int main(int argc, char *argv[])
 
     if(m_subtitle_index == -1 && !m_has_external_subtitles)
       m_player_subtitles.SetVisible(false);
-  }
-
-  m_omx_reader.GetHints(OMXSTREAM_AUDIO, m_hints_audio);
-
-  if (deviceString == "")
-  {
-    if (m_BcmHost.vc_tv_hdmi_audio_supported(EDID_AudioFormat_ePCM, 2, EDID_AudioSampleRate_e44KHz, EDID_AudioSampleSize_16bit ) == 0)
-      deviceString = "omx:hdmi";
-    else
-      deviceString = "omx:local";
-  }
-
-  if ((m_hints_audio.codec == CODEC_ID_AC3 || m_hints_audio.codec == CODEC_ID_EAC3) &&
-      m_BcmHost.vc_tv_hdmi_audio_supported(EDID_AudioFormat_eAC3, 2, EDID_AudioSampleRate_e44KHz, EDID_AudioSampleSize_16bit ) != 0)
-    m_passthrough = false;
-  if (m_hints_audio.codec == CODEC_ID_DTS &&
-      m_BcmHost.vc_tv_hdmi_audio_supported(EDID_AudioFormat_eDTS, 2, EDID_AudioSampleRate_e44KHz, EDID_AudioSampleSize_16bit ) != 0)
-    m_passthrough = false;
-
-  if(m_has_audio && !m_player_audio.Open(m_hints_audio, m_av_clock, &m_omx_reader, deviceString, 
-                                         m_passthrough, m_use_hw_audio,
-                                         m_boost_on_downmix, m_thread_player, m_live, m_layout, audio_queue_size, audio_fifo_size))
-    goto do_exit;
-
-  if(m_has_audio)
-  {
-    m_player_audio.SetVolume(pow(10, m_Volume / 2000.0));
-    if (m_Amplification)
-      m_player_audio.SetDynamicRangeCompression(m_Amplification);
   }
 
   if (m_threshold < 0.0f)

--- a/utils/SingleLock.h
+++ b/utils/SingleLock.h
@@ -48,7 +48,7 @@ protected:
 class CSingleLock
 {
 public:
-  inline CSingleLock(CCriticalSection& cs) { m_section = cs; m_section.Lock(); }
+  inline CSingleLock(CCriticalSection& cs):m_section(cs) { m_section.Lock(); }
   inline ~CSingleLock()                    { m_section.Unlock(); }
 
 protected:

--- a/utils/StdString.h
+++ b/utils/StdString.h
@@ -862,14 +862,14 @@ inline const Type& SSMAX(const Type& arg1, const Type& arg2)
     {
       PCSTR pNextSrcA      = pSrcA;
       PWSTR pNextDstW      = pDstW;
-      SSCodeCvt::result res  = SSCodeCvt::ok;
+      //SSCodeCvt::result res  = SSCodeCvt::ok;
       const SSCodeCvt& conv  = SS_USE_FACET(loc, SSCodeCvt);
 #if defined(TARGET_DARWIN)
       SSCodeCvt::state_type st= { { 0 } };
 #else
       SSCodeCvt::state_type st= { 0 };
 #endif
-      res            = conv.in(st,
+      SSCodeCvt::result res   = conv.in(st,
                     pSrcA, pSrcA + nSrc, pNextSrcA,
                     pDstW, pDstW + nDst, pNextDstW);
 #ifdef TARGET_LINUX
@@ -909,14 +909,14 @@ inline const Type& SSMAX(const Type& arg1, const Type& arg2)
     {
       PSTR pNextDstA      = pDstA;
       PCWSTR pNextSrcW    = pSrcW;
-      SSCodeCvt::result res  = SSCodeCvt::ok;
+      //SSCodeCvt::result res  = SSCodeCvt::ok;
       const SSCodeCvt& conv  = SS_USE_FACET(loc, SSCodeCvt);
 #if defined(TARGET_DARWIN)
       SSCodeCvt::state_type st= { { 0 } };
 #else
       SSCodeCvt::state_type st= { 0 };
 #endif
-      res            = conv.out(st,
+      SSCodeCvt::result res  = conv.out(st,
                     pSrcW, pSrcW + nSrc, pNextSrcW,
                     pDstA, pDstA + nDst, pNextDstA);
 #ifdef TARGET_LINUX
@@ -3291,6 +3291,7 @@ public:
              reinterpret_cast<PMYSTR>(&szTemp), 0, &argList) == 0 ||
        szTemp == 0 )
     {
+		va_end(argList);
       throw std::runtime_error("out of memory");
     }
     *this = szTemp;
@@ -3310,6 +3311,7 @@ public:
              reinterpret_cast<PMYSTR>(&szTemp), 0, &argList) == 0 ||
       szTemp == 0)
     {
+		va_end(argList);
       throw std::runtime_error("out of memory");
     }
     *this = szTemp;
@@ -3455,12 +3457,12 @@ public:
   {
     int nReplaced  = 0;
 
-    for ( MYITER iter=this->begin(); iter != this->end(); iter++ )
+    for ( MYITER iter=this->begin(); iter != this->end(); ++iter )
     {
       if ( *iter == chOld )
       {
         *iter = chNew;
-        nReplaced++;
+        ++nReplaced;
       }
     }
 


### PR DESCRIPTION
I decided to put these two together: 
fix almost all cppcheck issues;
Invert audio and video player Open(), to change allocation order for the buffers;

The second helps with #230 , it not solves completely because too little memory will trigger, but is much more easy to dynamically manage video_fifo size as the number of audio buffers is fixed.  