### PR TITLE
Reduce delay and visual stuttering with looping

### DIFF
--- a/OMXPlayerVideo.cpp
+++ b/OMXPlayerVideo.cpp
@@ -140,6 +140,31 @@ bool OMXPlayerVideo::Open(COMXStreamInfo &hints, OMXClock *av_clock, const CRect
   return true;
 }
 
+bool OMXPlayerVideo::Reset()
+{
+  // Quick reset of internal state back to a default that is ready to play from
+  // the start or a new position.  This replaces a combination of Close and then
+  // Open calls but does away with the DLL unloading/loading, decoder reset, and
+  // thread reset.
+  Flush();   
+  m_stream_id         = -1;
+  m_pStream           = NULL;
+  m_iCurrentPts       = DVD_NOPTS_VALUE;
+  m_frametime         = 0;
+  m_bAbort            = false;
+  m_flush             = false;
+  m_flush_requested   = false;
+  m_cached_size       = 0;
+  m_iVideoDelay       = 0;
+  m_history_valid_pts = ~0;  // From OpenDecoder.
+
+  // Keep consistency with old Close/Open logic by continuing to return a bool
+  // with the success/failure of this call.  Although little can go wrong
+  // setting some variables, in the future this could indicate success/failure
+  // of the reset.  For now just return success (true).
+  return true;
+}
+
 bool OMXPlayerVideo::Close()
 {
   m_bAbort  = true;

--- a/OMXPlayerVideo.h
+++ b/OMXPlayerVideo.h
@@ -88,6 +88,7 @@ public:
   bool Open(COMXStreamInfo &hints, OMXClock *av_clock, const CRect& DestRect, EDEINTERLACEMODE deinterlace, OMX_IMAGEFILTERANAGLYPHTYPE anaglyph, bool hdmi_clock_sync, bool use_thread,
                    float display_aspect, int display, int layer, float queue_size, float fifo_size);
   bool Close();
+  bool Reset();
   bool Decode(OMXPacket *pkt);
   void Process();
   void Flush();

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1486,15 +1486,12 @@ int main(int argc, char *argv[])
         }
       }
 
-      m_player_video.Close();
-
       sentStarted = false;
 
       if (m_omx_reader.IsEof())
         goto do_exit;
 
-      if(m_has_video && !m_player_video.Open(m_hints_video, m_av_clock, DestRect, m_Deinterlace ? VS_DEINTERLACEMODE_FORCE:m_NoDeinterlace ? VS_DEINTERLACEMODE_OFF:VS_DEINTERLACEMODE_AUTO,
-                                         m_anaglyph, m_hdmi_clock_sync, m_thread_player, m_display_aspect, m_display, m_layer, video_queue_size, video_fifo_size))
+      if(m_has_video && !m_player_video.Reset())
         goto do_exit;
 
       CLog::Log(LOGDEBUG, "Seeked %.0f %.0f %.0f\n", DVD_MSEC_TO_TIME(seek_pos), startpts, m_av_clock->OMXMediaTime());


### PR DESCRIPTION
This is a small optimization to the loop logic so that it doesn't do a full close and open of the video player component when looping to the start of a video.

Currently when a video loops back to the start the entire ffmpeg DLL is unloaded and reloaded, the GPU decoder logic is torn down and recreated again, and the decoding threading is destroyed and recreated.  This causes a noticeable delay and blanking of the screen which makes seamless looping impossible.

This change is to add a reset function to the video player component so that it can just do a minimal reset of the internal state back into what's necessary for playing video.  In particular it skips the DLL unload & load, GPU teardown & setup, etc.  The result is that looping happens much quicker and is nearly seamless.  There's still a ~100ms delay during the loop but the screen doesn't go black anymore so it's easier to work around by making a looped video start and stop with the same image.

The player code is quite complex (at least in the main file) so I can't claim to fully understand potential side effects from my change, but from some testing it doesn't appear to cause any issues with videos looping for a long period of time.  I tried to keep the change as small and isolated as possible so there's no chance of it messing up other parts of the code that don't deal with video looping.