### PR TITLE
DBUS: Implement 'non-stutter' setvideopos, hidevideo & unhidevideo

### DIFF
--- a/OMXPlayerVideo.cpp
+++ b/OMXPlayerVideo.cpp
@@ -201,6 +201,11 @@ void OMXPlayerVideo::SetAlpha(int alpha)
   m_decoder->SetAlpha(alpha);
 }
 
+void OMXPlayerVideo::SetVideoRect(const CRect& SrcRect, const CRect& DestRect)
+{
+  m_decoder->SetVideoRect(SrcRect, DestRect);
+}
+
 static unsigned count_bits(int32_t value)
 {
   unsigned bits = 0;

--- a/OMXPlayerVideo.h
+++ b/OMXPlayerVideo.h
@@ -108,6 +108,7 @@ public:
   void SetDelay(double delay) { m_iVideoDelay = delay; }
   double GetDelay() { return m_iVideoDelay; }
   void SetAlpha(int alpha);
+  void SetVideoRect(const CRect& SrcRect, const CRect& DestRect);
 
 };
 #endif


### PR DESCRIPTION
Allows the video layer to be moved, resized, hidden and unhidden without the need to go through the expensive close/open file sequence.