### PR TITLE
Normal exit status on user quit or playback end

### DIFF
--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1779,5 +1779,9 @@ do_exit:
   g_RBP.Deinitialize();
 
   printf("have a nice day ;)\n");
+
+  // normal exit status on user quit or playback end
+  if (m_stop || m_send_eos)
+    return 0;
   return 1;
 }


### PR DESCRIPTION
This helps wrappers scripts figure out what happened.  Also, tools like
mps-youtube will try a different stream quality on error.