### PR TITLE
Play entire video before looping.

### DIFF
--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1671,11 +1671,6 @@ int main(int argc, char *argv[])
         OMXClock::OMXSleep(10);
         continue;
       }
-      if (m_loop)
-      {
-        m_incr = m_loop_from - (m_av_clock->OMXMediaTime() ? m_av_clock->OMXMediaTime() / DVD_TIME_BASE : last_seek_pos);
-        continue;
-      }
       if (!m_send_eos && m_has_video)
         m_player_video.SubmitEOS();
       if (!m_send_eos && m_has_audio)
@@ -1687,6 +1682,13 @@ int main(int argc, char *argv[])
         OMXClock::OMXSleep(10);
         continue;
       }
+
+      if (m_loop)
+      {
+        m_incr = m_loop_from - (m_av_clock->OMXMediaTime() ? m_av_clock->OMXMediaTime() / DVD_TIME_BASE : last_seek_pos);
+        continue;
+      }
+
       break;
     }
 


### PR DESCRIPTION
When looping video, omxplayer seeks back to the initial position 2-3 seconds early (this behaviour is seen in 74aac3). I can see there is another pull request claiming to resolve the same issue - I'm not sure if their way is better.

Here is a video that can be used to demonstrate the problem: http://divinelegy.com/wasteland/GenRun/%d0%20is%20for%20%d0ogecoin.mp4

All I have done is moved the loop logic to _after_ EOS is submitted. This seems to let the remaining video play out. I'm not sure if this is wise or not, but it seems to work.

