### PR TITLE
prepare-native-raspbian.sh: complete overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ffmpeg_compiled
 ffmpeg
 help.h
 keys.h
+patch.flag

--- a/prepare-native-raspbian.sh
+++ b/prepare-native-raspbian.sh
@@ -20,7 +20,7 @@ done
 echo ""
 if [ ! -z "$MISSING_PKGS" ]; then
 	echo "You are missing required packages."
-	echo "Run apt-get update && apt-get install $MISSING_PKGS"
+	echo "Run sudo apt-get update && sudo apt-get install $MISSING_PKGS"
 	exit 1
 else
 	echo "All dependencies met"
@@ -89,7 +89,7 @@ done
 echo ""
 if [ ! -z "$MISSING_PKGS" ]; then
 	echo "You are missing required packages."
-	echo "Run apt-get update && apt-get install $MISSING_PKGS"
+	echo "Run sudo apt-get update && sudo apt-get install $MISSING_PKGS"
 	echo "Alternative: install rpi-update with sudo wget http://goo.gl/1BOfJ -O /usr/local/bin/rpi-update && sudo chmod +x /usr/local/bin/rpi-update && sudo rpi-update"
 	exit 1
 else

--- a/prepare-native-raspbian.sh
+++ b/prepare-native-raspbian.sh
@@ -1,7 +1,37 @@
 #!/bin/sh
 
-echo "Patching makefiles..."
-echo "FLOAT=hard
+check_dpkg_installed() {
+	echo -n "."
+	if [ $(dpkg-query -W -f='${Status}' $1 2>/dev/null | grep -c "ok installed") -eq 0 ];
+	then
+		MISSING_PKGS="$MISSING_PKGS $1"
+	fi
+}
+
+echo "Modifying for native build on Debian"
+
+echo "Checking dpkg database for missing packages"
+REQUIRED_PKGS="ca-certificates git-core subversion binutils libva1 libpcre3-dev libidn11-dev libboost1.50-dev libfreetype6-dev libusb-1.0-0-dev libdbus-1-dev libssl-dev libssh-dev libsmbclient-dev gcc-4.7 g++-4.7 sed pkg-config"
+MISSING_PKGS=""
+for pkg in $REQUIRED_PKGS
+do
+	check_dpkg_installed $pkg
+done
+echo ""
+if [ ! -z "$MISSING_PKGS" ]; then
+	echo "You are missing required packages."
+	echo "Run apt-get update && apt-get install $MISSING_PKGS"
+	exit 1
+else
+	echo "All dependencies met"
+fi
+
+if [ -e "patch.flag" ]
+then
+	echo "Makefiles already patched, nothing to do here"
+else
+	echo "Patching makefiles..."
+	echo "FLOAT=hard
 
 CFLAGS +=  -mfloat-abi=hard -mcpu=arm1176jzf-s -fomit-frame-pointer -mabi=aapcs-linux -mtune=arm1176jzf-s -mfpu=vfp -Wno-psabi -mno-apcs-stack-check -O3 -mstructure-size-boundary=32 -mno-sched-prolog -march=armv6zk `pkg-config dbus-1 --cflags`
 
@@ -25,15 +55,15 @@ INCLUDES	+= -I/opt/vc/include/interface/vcos/pthreads \
 			-I/usr/include \
 			-I/usr/include/freetype2" > Makefile.include
 
-sed -i '/--enable-cross-compile \\/d;' Makefile.ffmpeg
-sed -i 's/			--cross-prefix=$(HOST)-//g;' Makefile.ffmpeg
+	sed -i '/--enable-cross-compile \\/d;' Makefile.ffmpeg
+	sed -i 's/			--cross-prefix=$(HOST)-//g;' Makefile.ffmpeg
 
-sed -i 's/$(HOST)-//g;' Makefile.*
-sed -i 's/ -j9//g;' Makefile.*
-sed -i 's/#arm-unknown-linux-gnueabi-strip/arm-unknown-linux-gnueabi-strip/g;' Makefile
-sed -i 's/arm-unknown-linux-gnueabi-strip/strip/g;' Makefile
+	sed -i 's/$(HOST)-//g;' Makefile.*
+	sed -i 's/ -j9//g;' Makefile.*
+	sed -i 's/#arm-unknown-linux-gnueabi-strip/arm-unknown-linux-gnueabi-strip/g;' Makefile
+	sed -i 's/arm-unknown-linux-gnueabi-strip/strip/g;' Makefile
 
-cat <<EOF >>Makefile
+	cat <<EOF >>Makefile
 install:
 	cp -r \$(DIST)/* /
 
@@ -44,19 +74,45 @@ uninstall:
 	rm -rf /usr/share/doc/omxplayer
 	rm -rf /usr/share/man/man1/omxplayer.1
 EOF
+	touch "patch.flag"
+fi
 
-echo "Installing packages..."
-sudo apt-get update
-sudo apt-get -y install ca-certificates git-core subversion binutils libva1 libpcre3-dev libidn11-dev libboost1.50-dev libfreetype6-dev libusb-1.0-0-dev libdbus-1-dev libssl-dev libssh-dev libsmbclient-dev
-sudo apt-get -y install gcc-4.7 g++-4.7
+echo "Checking for OMX development headers"
+# These can either be supplied by dpkg or via rpi-update.
+# First, check dpkg to avoid messing with dpkg-managed files!
+REQUIRED_PKGS="libraspberrypi-dev libraspberrypi0 libraspberrypi-bin"
+MISSING_PKGS=""
+for pkg in $REQUIRED_PKGS
+do
+	check_dpkg_installed $pkg
+done
+echo ""
+if [ ! -z "$MISSING_PKGS" ]; then
+	echo "You are missing required packages."
+	echo "Run apt-get update && apt-get install $MISSING_PKGS"
+	echo "Alternative: install rpi-update with sudo wget http://goo.gl/1BOfJ -O /usr/local/bin/rpi-update && sudo chmod +x /usr/local/bin/rpi-update && sudo rpi-update"
+	exit 1
+else
+	echo "All dependencies met"
+fi
 
-
-echo "Installing the rpi-update script..."
-sudo wget http://goo.gl/1BOfJ -O /usr/bin/rpi-update && sudo chmod +x /usr/bin/rpi-update
-echo "Updating firmware..."
-sudo rpi-update
-
-echo "In order to compile ffmpeg you need to set memory_split to 16 for 256MB RAM PIs (0 does not work) or to at most 256 for 512MB RAM PIs, respectively. Otherwise there is not enough RAM to compile ffmpeg. Please do the apropriate in the raspi-config and select finish to reboot your RPi. Warning: to run compiled omxplayer please start raspi-config again and set memory_split to at least 128. [Press RETURN to continue]"
-read -r REPLY
-sudo raspi-config
-
+echo "Checking amount of RAM in system"
+#We require ~230MB of total RAM
+TOTAL_RAM=`grep MemTotal /proc/meminfo | awk '{print $2}'`
+TOTAL_SWAP=`grep SwapTotal /proc/meminfo | awk '{print $2}'`
+if [ "$TOTAL_RAM" -lt 230000 ]; then
+	echo "Your system has $TOTAL_RAM kB RAM available, which is too low. Checking swap space."
+	if [ "$TOTAL_SWAP" -lt 230000 ]; then
+		echo "Your system has $TOTAL_SWAP kB swap available, which is too low."
+		echo "In order to compile ffmpeg you need to set memory_split to 16 for 256MB RAM PIs (0 does not work) or to at most 256 for 512MB RAM PIs, respectively."
+		echo "Otherwise there is not enough RAM to compile ffmpeg. Please do the apropriate in the raspi-config and select finish to reboot your RPi."
+		echo "Warning: to run compiled omxplayer please start raspi-config again and set memory_split to at least 128."
+	else
+		echo "You have enough swap space to compile, but speed will be lower and SD card wear will be increased."
+		echo "In order to compile ffmpeg you need to set memory_split to 16 for 256MB RAM PIs (0 does not work) or to at most 256 for 512MB RAM PIs, respectively."
+		echo "Otherwise there is not enough RAM to compile ffmpeg. Please do the apropriate in the raspi-config and select finish to reboot your RPi."
+		echo "Warning: to run compiled omxplayer please start raspi-config again and set memory_split to at least 128."
+	fi
+else
+	echo "You should have enough RAM available to successfully compile and run omxplayer."
+fi


### PR DESCRIPTION
Repost of #352 because I forgot to create a separate branch

prepare-native-raspbian.sh no longer uses sudo privileges and especially does not modify the system
in any way. Actions like package installs must now be done explicitly by the user.

ToDo: get rid of prepare-native-raspbian.sh and instead use the standard Debian packaging system