### PR TITLE
Added --crop option, to set crop area for input video

### DIFF
--- a/OMXVideo.cpp
+++ b/OMXVideo.cpp
@@ -169,7 +169,7 @@ bool COMXVideo::PortSettingsChanged()
         port_image.format.video.nFrameWidth, port_image.format.video.nFrameHeight,
         port_image.format.video.xFramerate / (float)(1<<16), 0, m_deinterlace, m_config.anaglyph, m_pixel_aspect, m_config.display, m_config.layer);
 
-    SetVideoRect(m_src_rect, m_config.dst_rect);
+    SetVideoRect(m_config.src_rect, m_config.dst_rect);
     m_omx_decoder.EnablePort(m_omx_decoder.GetOutputPort(), true);
     return true;
   }
@@ -226,7 +226,7 @@ bool COMXVideo::PortSettingsChanged()
     return false;
   }
 
-  SetVideoRect(m_src_rect, m_config.dst_rect);
+  SetVideoRect(m_config.src_rect, m_config.dst_rect);
 
   if(m_config.hdmi_clock_sync)
   {
@@ -377,7 +377,6 @@ bool COMXVideo::Open(OMXClock *clock, const OMXVideoConfig &config)
   m_setStartTime = true;
 
   m_config = config;
-  m_src_rect.SetRect(0, 0, 0, 0);
 
   m_video_codec_name      = "";
   m_codingType            = OMX_VIDEO_CodingUnused;
@@ -840,11 +839,6 @@ void COMXVideo::SetVideoRect(const CRect& SrcRect, const CRect& DestRect)
     configDisplay.dest_rect.y_offset  = (int)(DestRect.y1+0.5f);
     configDisplay.dest_rect.width     = (int)(DestRect.Width()+0.5f);
     configDisplay.dest_rect.height    = (int)(DestRect.Height()+0.5f);
-
-    configDisplay.src_rect.x_offset   = (int)(SrcRect.x1+0.5f);
-    configDisplay.src_rect.y_offset   = (int)(SrcRect.y1+0.5f);
-    configDisplay.src_rect.width      = (int)(SrcRect.Width()+0.5f);
-    configDisplay.src_rect.height     = (int)(SrcRect.Height()+0.5f);
   }
   else /* if (m_pixel_aspect != 0.0f) */
   {
@@ -852,6 +846,14 @@ void COMXVideo::SetVideoRect(const CRect& SrcRect, const CRect& DestRect)
     configDisplay.set      = OMX_DISPLAY_SET_PIXEL;
     configDisplay.pixel_x  = aspect.num;
     configDisplay.pixel_y  = aspect.den;
+  }
+  if (SrcRect.x2 > SrcRect.x1 && SrcRect.y2 > SrcRect.y1 || DestRect.x2 > DestRect.x1 && DestRect.y2 > DestRect.y1)
+  {
+    configDisplay.set                 = (OMX_DISPLAYSETTYPE)(configDisplay.set|OMX_DISPLAY_SET_SRC_RECT);
+    configDisplay.src_rect.x_offset   = (int)(SrcRect.x1+0.5f);
+    configDisplay.src_rect.y_offset   = (int)(SrcRect.y1+0.5f);
+    configDisplay.src_rect.width      = (int)(SrcRect.Width()+0.5f);
+    configDisplay.src_rect.height     = (int)(SrcRect.Height()+0.5f);
   }
   omx_err = m_omx_render.SetConfig(OMX_IndexConfigDisplayRegion, &configDisplay);
   if(omx_err != OMX_ErrorNone)

--- a/OMXVideo.h
+++ b/OMXVideo.h
@@ -50,6 +50,7 @@ public:
   COMXStreamInfo hints;
   bool use_thread;
   CRect dst_rect;
+  CRect src_rect;
   float display_aspect;
   EDEINTERLACEMODE deinterlace;
   bool advanced_hd_deinterlace;
@@ -66,6 +67,7 @@ public:
   {
     use_thread = true;
     dst_rect.SetRect(0, 0, 0, 0);
+    src_rect.SetRect(0, 0, 0, 0);
     display_aspect = 0.0f;
     deinterlace = VS_DEINTERLACEMODE_AUTO;
     advanced_hd_deinterlace = false;
@@ -131,7 +133,6 @@ protected:
   std::string       m_video_codec_name;
 
   bool              m_deinterlace;
-  CRect             m_src_rect;
   OMXVideoConfig    m_config;
 
   float             m_pixel_aspect;

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Usage: omxplayer [OPTIONS] [FILE]
         --lines n               Number of lines in the subtitle buffer (default: 3)
         --win 'x1 y1 x2 y2'     Set position of video window
         --win x1,y1,x2,y2       Set position of video window
+        --crop 'x1 y1 x2 y2'    Set crop area for input video
+        --crop x1,y1,x2,y2      Set crop area for input video
         --audio_fifo  n         Size of audio output fifo in seconds
         --video_fifo  n         Size of video output fifo in MB
         --audio_queue n         Size of audio input queue in MB

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -516,7 +516,6 @@ int main(int argc, char *argv[])
   FORMAT_3D_T           m_3d                  = CONF_FLAGS_FORMAT_NONE;
   bool                  m_refresh             = false;
   double                startpts              = 0;
-  CRect                 SrcRect               = {0,0,0,0};
   bool                  m_blank_background    = false;
   bool sentStarted = false;
   float m_threshold      = -1.0f; // amount of audio/video required to come out of buffering
@@ -565,6 +564,7 @@ int main(int argc, char *argv[])
   const int advanced_opt    = 0x211;
   const int http_cookie_opt = 0x300;
   const int http_user_agent_opt = 0x301;
+  const int crop_opt        = 0x302;
 
   struct option longopts[] = {
     { "info",         no_argument,        NULL,          'i' },
@@ -601,6 +601,7 @@ int main(int argc, char *argv[])
     { "subtitles",    required_argument,  NULL,          subtitles_opt },
     { "lines",        required_argument,  NULL,          lines_opt },
     { "win",          required_argument,  NULL,          pos_opt },
+    { "crop",         required_argument,  NULL,          crop_opt },
     { "audio_fifo",   required_argument,  NULL,          audio_fifo_opt },
     { "video_fifo",   required_argument,  NULL,          video_fifo_opt },
     { "audio_queue",  required_argument,  NULL,          audio_queue_opt },
@@ -774,6 +775,10 @@ int main(int argc, char *argv[])
       case pos_opt:
         sscanf(optarg, "%f %f %f %f", &m_config_video.dst_rect.x1, &m_config_video.dst_rect.y1, &m_config_video.dst_rect.x2, &m_config_video.dst_rect.y2) == 4 ||
         sscanf(optarg, "%f,%f,%f,%f", &m_config_video.dst_rect.x1, &m_config_video.dst_rect.y1, &m_config_video.dst_rect.x2, &m_config_video.dst_rect.y2);
+        break;
+      case crop_opt:
+        sscanf(optarg, "%f %f %f %f", &m_config_video.src_rect.x1, &m_config_video.src_rect.y1, &m_config_video.src_rect.x2, &m_config_video.src_rect.y2) == 4 ||
+        sscanf(optarg, "%f,%f,%f,%f", &m_config_video.src_rect.x1, &m_config_video.src_rect.y1, &m_config_video.src_rect.x2, &m_config_video.src_rect.y2);
         break;
       case vol_opt:
 	m_Volume = atoi(optarg);
@@ -1415,7 +1420,7 @@ int main(int argc, char *argv[])
         break;
       case KeyConfig::ACTION_MOVE_VIDEO:
         sscanf(result.getWinArg(), "%f %f %f %f", &m_config_video.dst_rect.x1, &m_config_video.dst_rect.y1, &m_config_video.dst_rect.x2, &m_config_video.dst_rect.y2);
-        m_player_video.SetVideoRect(SrcRect,m_config_video.dst_rect);
+        m_player_video.SetVideoRect(m_config_video.src_rect, m_config_video.dst_rect);
         break;
       case KeyConfig::ACTION_HIDE_VIDEO:
         // set alpha to minimum


### PR DESCRIPTION
Current support for cropping enforces fullscreen mode. By using a dedicated crop option, one can use both --win and --crop options, which is needed in some cases.

Note that I did not add support for key mappings or dbus, only as an argument.