### PR TITLE
Allow aspect mode to be configured.

### DIFF
--- a/KeyConfig.h
+++ b/KeyConfig.h
@@ -38,7 +38,9 @@ class KeyConfig
         ACTION_UNHIDE_VIDEO = 29,
         ACTION_HIDE_SUBTITLES = 30,
         ACTION_SHOW_SUBTITLES = 31,
-        ACTION_SET_ALPHA=32
+        ACTION_SET_ALPHA = 32,
+        ACTION_SET_ASPECT_MODE = 33,
+        ACTION_CROP_VIDEO = 34
     };
 
     #define KEY_LEFT 0x5b44

--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -303,6 +303,30 @@ OMXControlResult OMXControl::getEvent()
       }
     }
 
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "SetAspectMode"))
+    {
+      DBusError error;
+      dbus_error_init(&error);
+
+      const char *aspectMode;
+      const char *oPath; // ignoring path right now because we don't have a playlist
+      dbus_message_get_args(m, &error, DBUS_TYPE_OBJECT_PATH, &oPath, DBUS_TYPE_STRING, &aspectMode, DBUS_TYPE_INVALID);
+
+      // Make sure a value is sent for setting aspect mode
+      if (dbus_error_is_set(&error))
+      {
+            CLog::Log(LOGWARNING, "SetAspectMode D-Bus Error: %s", error.message );
+            dbus_error_free(&error);
+            dbus_respond_ok(m);
+            return KeyConfig::ACTION_BLANK;
+      }
+      else
+      {
+            dbus_respond_string(m, aspectMode);
+            return OMXControlResult(KeyConfig::ACTION_SET_ASPECT_MODE, aspectMode);
+      }
+    }
+
 
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "PlaybackStatus"))
   {
@@ -452,6 +476,29 @@ OMXControlResult OMXControl::getEvent()
     {
       dbus_respond_string(m, win);
       return OMXControlResult(KeyConfig::ACTION_MOVE_VIDEO, win);
+    }
+  }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "SetVideoCropPos"))
+  {
+    DBusError error;
+    dbus_error_init(&error);
+
+    const char *crop;
+    const char *oPath; // ignoring path right now because we don't have a playlist
+    dbus_message_get_args(m, &error, DBUS_TYPE_OBJECT_PATH, &oPath, DBUS_TYPE_STRING, &crop, DBUS_TYPE_INVALID);
+
+    // Make sure a value is sent for setting SetVideoCropPos
+    if (dbus_error_is_set(&error))
+    {
+      CLog::Log(LOGWARNING, "SetVideoCropPos D-Bus Error: %s", error.message );
+      dbus_error_free(&error);
+      dbus_respond_ok(m);
+      return KeyConfig::ACTION_BLANK;
+    }
+    else
+    {
+      dbus_respond_string(m, crop);
+      return OMXControlResult(KeyConfig::ACTION_CROP_VIDEO, crop);
     }
   }
   else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "HideVideo"))

--- a/OMXPlayerVideo.cpp
+++ b/OMXPlayerVideo.cpp
@@ -184,6 +184,11 @@ void OMXPlayerVideo::SetVideoRect(const CRect& SrcRect, const CRect& DestRect)
   m_decoder->SetVideoRect(SrcRect, DestRect);
 }
 
+void OMXPlayerVideo::SetVideoRect(int aspectMode)
+{
+  m_decoder->SetVideoRect(aspectMode);
+}
+
 bool OMXPlayerVideo::Decode(OMXPacket *pkt)
 {
   if(!pkt)

--- a/OMXPlayerVideo.h
+++ b/OMXPlayerVideo.h
@@ -97,6 +97,7 @@ public:
   double GetDelay() { return m_iVideoDelay; }
   void SetAlpha(int alpha);
   void SetVideoRect(const CRect& SrcRect, const CRect& DestRect);
+  void SetVideoRect(int aspectMode);
 
 };
 #endif

--- a/OMXVideo.h
+++ b/OMXVideo.h
@@ -50,6 +50,7 @@ public:
   COMXStreamInfo hints;
   bool use_thread;
   CRect dst_rect;
+  CRect src_rect;
   float display_aspect;
   EDEINTERLACEMODE deinterlace;
   bool advanced_hd_deinterlace;
@@ -57,6 +58,7 @@ public:
   bool hdmi_clock_sync;
   bool allow_mvc;
   int alpha;
+  int aspectMode;
   int display;
   int layer;
   float queue_size;
@@ -66,6 +68,7 @@ public:
   {
     use_thread = true;
     dst_rect.SetRect(0, 0, 0, 0);
+    src_rect.SetRect(0, 0, 0, 0);
     display_aspect = 0.0f;
     deinterlace = VS_DEINTERLACEMODE_AUTO;
     advanced_hd_deinterlace = false;
@@ -73,6 +76,7 @@ public:
     hdmi_clock_sync = false;
     allow_mvc = false;
     alpha = 255;
+    aspectMode = 0;
     display = 0;
     layer = 0;
     queue_size = 10.0f;
@@ -93,6 +97,7 @@ public:
   bool NaluFormatStartCodes(enum AVCodecID codec, uint8_t *in_extradata, int in_extrasize);
   bool Open(OMXClock *clock, const OMXVideoConfig &config);
   bool PortSettingsChanged();
+  void PortSettingsChangedLogger(OMX_PARAM_PORTDEFINITIONTYPE port_image, int interlaceEMode);
   void Close(void);
   unsigned int GetFreeSpace();
   unsigned int GetSize();
@@ -101,6 +106,8 @@ public:
   void SetDropState(bool bDrop);
   std::string GetDecoderName() { return m_video_codec_name; };
   void SetVideoRect(const CRect& SrcRect, const CRect& DestRect);
+  void SetVideoRect(int aspectMode);
+  void SetVideoRect();
   void SetAlpha(int alpha);
   int GetInputBufferSize();
   void SubmitEOS();
@@ -131,7 +138,6 @@ protected:
   std::string       m_video_codec_name;
 
   bool              m_deinterlace;
-  CRect             m_src_rect;
   OMXVideoConfig    m_config;
 
   float             m_pixel_aspect;

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Usage: omxplayer [OPTIONS] [FILE]
         --lines n               Number of lines in the subtitle buffer (default: 3)
         --win 'x1 y1 x2 y2'     Set position of video window
         --win x1,y1,x2,y2       Set position of video window
+        --crop 'x1 y1 x2 y2'    Set crop area for input video
+        --crop x1,y1,x2,y2      Set crop area for input video
+        --aspect-mode type      Letterbox, fill, stretch. Default: stretch if win is specified, letterbox otherwise
         --audio_fifo  n         Size of audio output fifo in seconds
         --video_fifo  n         Size of video output fifo in MB
         --audio_queue n         Size of audio input queue in MB

--- a/dbuscontrol.sh
+++ b/dbuscontrol.sh
@@ -61,6 +61,14 @@ setvideopos)
 	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.VideoPos objpath:/not/used string:"$2 $3 $4 $5" >/dev/null
 	;;
 
+setvideocroppos)
+	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.SetVideoCropPos objpath:/not/used string:"$2 $3 $4 $5" >/dev/null
+	;;
+
+setaspectmode)
+	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.SetAspectMode objpath:/not/used string:"$2" >/dev/null
+	;;
+
 hidevideo)
 	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:28 >/dev/null
 	;;
@@ -90,7 +98,7 @@ showsubtitles)
 	;;
 
 *)
-	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|togglesubtitles|hidesubtitles|showsubtitles|setvideopos [x1 y1 x2 y2]|setalpha [alpha (0..255)]" >&2
+	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|togglesubtitles|hidesubtitles|showsubtitles|setvideopos [x1 y1 x2 y2]|setvideocroppos [x1 y1 x2 y2]|setaspectmode [letterbox,fill,stretch,default]|setalpha [alpha (0..255)]" >&2
 	exit 1
 	;;
 esac


### PR DESCRIPTION
This patch adds a new option to control the aspect mode.

It supports three modes:
- `letterbox`, which adds black borders to fit the video into the display area without cropping or stretching;
- `fill`, which crops the video to fill the whole display area without stretching;
- `stretch`, which stretches the video to fill the whole display area without cropping.

The default is `letterbox` if the `win` parameter is not used, `stretch` otherwise. This is the same behaviour as it was before this patch.

The patch also adds a way to control cropping of the video (enhancing and superseding #374).

Cheers,
Vittorio