### PR TITLE
pthread-related bugfixes and minor cross-platform cleanup

### DIFF
--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <sys/mman.h>
-#include <linux/fb.h>
 #include <string.h>
 #include <dbus/dbus.h>
 

--- a/OMXThread.cpp
+++ b/OMXThread.cpp
@@ -41,8 +41,8 @@
 OMXThread::OMXThread()
 {
   pthread_mutex_init(&m_lock, NULL);
-  pthread_attr_setdetachstate(&m_tattr, PTHREAD_CREATE_JOINABLE);
   pthread_attr_init(&m_tattr);
+  pthread_attr_setdetachstate(&m_tattr, PTHREAD_CREATE_JOINABLE);
   m_thread    = 0;
   m_bStop     = false;
   m_running   = false;

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -23,7 +23,6 @@
 #include <stdint.h>
 #include <termios.h>
 #include <sys/mman.h>
-#include <linux/fb.h>
 #include <sys/ioctl.h>
 #include <getopt.h>
 #include <string.h>

--- a/utils/SingleLock.h
+++ b/utils/SingleLock.h
@@ -40,6 +40,10 @@ public:
   inline void Lock()         { pthread_mutex_lock(&m_lock); }
   inline void Unlock()       { pthread_mutex_unlock(&m_lock); }
 
+private:
+  CCriticalSection(CCriticalSection &other) = delete;
+  CCriticalSection& operator=(const CCriticalSection&) = delete;
+
 protected:
   pthread_mutex_t m_lock;
 };
@@ -48,11 +52,11 @@ protected:
 class CSingleLock
 {
 public:
-  inline CSingleLock(CCriticalSection& cs) { m_section = cs; m_section.Lock(); }
+  inline CSingleLock(CCriticalSection& cs) : m_section(cs) { m_section.Lock(); }
   inline ~CSingleLock()                    { m_section.Unlock(); }
 
 protected:
-  CCriticalSection m_section;
+  CCriticalSection &m_section;
 };
 
 


### PR DESCRIPTION
With these fixes omxplayer successfully runs on FreeBSD. It fixes two issues on this OS: 

- Bug fixed in OMXThread.cpp was a crash bug, mutex attribute is actually opaque memory structure on freebsd, so use before initialization was referencing some random memory
- Bug in utils/SingleLock.h caused random deadlock and random crashes for the same reason. Copy of CCriticalSection destroys pthread_mutex_t, freeing the memory it uses and whenever it's reused behavior is undefined

Minor cleanup of linux/fb.h header is just to cleanup code and reduce number of patches in port