### PR TITLE
DBUS: Add operation GetSource returning currently played file/stream

### DIFF
--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -342,6 +342,11 @@ OMXControlResult OMXControl::getEvent()
     dbus_respond_string(m, status);
     return KeyConfig::ACTION_BLANK;
   }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "GetSource"))
+  {
+    dbus_respond_string(m, reader->getFilename().c_str());
+    return KeyConfig::ACTION_BLANK;
+  }
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Volume"))
   {
     DBusError error;

--- a/OMXReader.h
+++ b/OMXReader.h
@@ -168,6 +168,7 @@ public:
   int GetAudioIndex() { return (m_audio_index >= 0) ? m_streams[m_audio_index].index : -1; };
   int GetSubtitleIndex() { return (m_subtitle_index >= 0) ? m_streams[m_subtitle_index].index : -1; };
   int GetVideoIndex() { return (m_video_index >= 0) ? m_streams[m_video_index].index : -1; };
+  std::string getFilename() const { return m_filename; }
 
   int GetRelativeIndex(size_t index)
   {

--- a/README.md
+++ b/README.md
@@ -337,6 +337,14 @@ The current state of the player, either "Paused" or "Playing".
 :-------------: | ---------
  Return         | `string` 
 
+#### GetSource
+
+The current file or stream that is being played.
+
+   Params       |   Type
+:-------------: | ---------
+ Return         | `string` 
+
 #### Volume
 
 When called with an argument it will set the volume and return the current

--- a/dbuscontrol.sh
+++ b/dbuscontrol.sh
@@ -96,7 +96,10 @@ hidesubtitles)
 showsubtitles)
 	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:31 >/dev/null
 	;;
-
+getsource)
+	source=$(dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.GetSource)
+	echo "$source" | sed 's/^ *//'
+	;;
 *)
 	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|togglesubtitles|hidesubtitles|showsubtitles|setvideopos [x1 y1 x2 y2]|setvideocroppos [x1 y1 x2 y2]|setaspectmode [letterbox,fill,stretch,default]|setalpha [alpha (0..255)]" >&2
 	exit 1


### PR DESCRIPTION
Adds a DBUS operation "GetSource" to the server and to the console client:

dbuscontrol.sh getsource

OMXReader's m_filename has been exposed via «std::string getFilename() const».

Fixes #365 