### PR TITLE
Play multiple files

### DIFF
--- a/KeyConfig.cpp
+++ b/KeyConfig.cpp
@@ -128,6 +128,8 @@ map<int, int> KeyConfig::buildDefaultKeymap()
     keymap['v'] = ACTION_STEP;
     keymap['w'] = ACTION_SHOW_SUBTITLES;
     keymap['x'] = ACTION_HIDE_SUBTITLES;
+    keymap['b'] = ACTION_PREVIOUS_FILE;
+    keymap['a'] = ACTION_NEXT_FILE;
 
     return keymap;
 }

--- a/KeyConfig.h
+++ b/KeyConfig.h
@@ -40,7 +40,9 @@ class KeyConfig
         ACTION_SHOW_SUBTITLES = 31,
         ACTION_SET_ALPHA = 32,
         ACTION_SET_ASPECT_MODE = 33,
-        ACTION_CROP_VIDEO = 34
+        ACTION_CROP_VIDEO = 34,
+        ACTION_PREVIOUS_FILE = 35,
+        ACTION_NEXT_FILE = 36,
     };
 
     #define KEY_LEFT 0x5b44

--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -221,6 +221,16 @@ OMXControlResult OMXControl::getEvent()
     dbus_respond_ok(m);
     return KeyConfig::ACTION_PREVIOUS_CHAPTER;
   }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "NextFile"))
+  {
+    dbus_respond_ok(m);
+    return KeyConfig::ACTION_NEXT_FILE;
+  }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "PreviousFile"))
+  {
+    dbus_respond_ok(m);
+    return KeyConfig::ACTION_PREVIOUS_FILE;
+  }
   else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "Pause")
         || dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "PlayPause"))
   {

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Copy over `omxplayer-dist/*` to the Pi `/`.
 
 ## SYNOPSIS
 
-Usage: omxplayer [OPTIONS] [FILE]
+Usage: omxplayer [OPTIONS] [FILE] ...
 
     -h  --help                  Print this help
     -v  --version               Print version info
@@ -113,7 +113,7 @@ Usage: omxplayer [OPTIONS] [FILE]
 
 For example:
 
-    ./omxplayer -p -o hdmi test.mkv
+    ./omxplayer -p -o hdmi test.mkv test2.mpeg
 
 ## KEY BINDINGS
 
@@ -128,6 +128,8 @@ Key bindings to control omxplayer while playing:
     k           next audio stream
     i           previous chapter
     o           next chapter
+    b           previous file
+    a           next file
     n           previous subtitle stream
     m           next subtitle stream
     s           toggle subtitles
@@ -159,6 +161,8 @@ The list of valid [action]s roughly corresponds to the list of default key bindi
     NEXT_AUDIO
     PREVIOUS_CHAPTER
     NEXT_CHAPTER
+    PREVIOUS_FILE
+    NEXT_FILE
     PREVIOUS_SUBTITLE
     NEXT_SUBTITLE
     TOGGLE_SUBTITLE
@@ -421,6 +425,22 @@ Skip to the next chapter.
 #### Previous
 
 Skip to the previous chapter.
+
+   Params       |   Type
+:-------------: | -------
+ Return         | `null` 
+
+#### NextFile
+
+Skip to the next file.
+
+   Params       |   Type
+:-------------: | -------
+ Return         | `null` 
+
+#### PreviousFile
+
+Skip to the previous file.
 
    Params       |   Type
 :-------------: | -------

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -524,6 +524,7 @@ int main(int argc, char *argv[])
   TV_DISPLAY_STATE_T   tv_state;
   double last_seek_pos = 0;
   bool idle = false;
+  bool m_continue = true;
   std::string            m_cookie              = "";
   std::string            m_user_agent          = "";
 
@@ -906,6 +907,9 @@ int main(int argc, char *argv[])
     return 0;
   }
 
+  int firstFileIndex = optind;
+  while(optind < argc) {
+	m_continue = false;
   m_filename = argv[optind];
 
   auto PrintFileNotFound = [](const std::string& path)
@@ -1378,6 +1382,16 @@ int main(int argc, char *argv[])
         m_stop = true;
         goto do_exit;
         break;
+      case KeyConfig::ACTION_NEXT_FILE:
+        goto do_continue;
+        break;
+      case KeyConfig::ACTION_PREVIOUS_FILE:
+    	  if(optind > firstFileIndex){
+    		  // will be increased by one at the end of the loop
+    		  optind-=2;
+    	  }
+        goto do_continue;
+        break;
       case KeyConfig::ACTION_SEEK_BACK_SMALL:
         if(m_omx_reader.CanSeek()) m_incr = -30.0;
         break;
@@ -1516,7 +1530,7 @@ int main(int argc, char *argv[])
       sentStarted = false;
 
       if (m_omx_reader.IsEof())
-        goto do_exit;
+        goto do_continue;
 
       // Quick reset to reduce delay during loop & seek.
       if (m_has_video && !m_player_video.Reset())
@@ -1773,6 +1787,8 @@ int main(int argc, char *argv[])
     }
   }
 
+do_continue:
+	m_continue = true;
 do_exit:
   if (m_stats)
     printf("\n");
@@ -1821,6 +1837,11 @@ do_exit:
   g_OMX.Deinitialize();
   g_RBP.Deinitialize();
 
+  	  if(!m_continue){
+  		  break;
+  	  }
+  	  optind++;
+  }
   printf("have a nice day ;)\n");
 
   // normal exit status on user quit or playback end


### PR DESCRIPTION
Dear all,

for the use of omxplayer as an audio-player, I needed the ability to play several files in a row. I tried the trick using a pipe and pipe:0 as the file, but this doesn't work for all audio formats (e.g. not for m4a). 
Thus, I enhanced omxplayer by the ability to play several files specified on the command line. You can switch between them using the key board shortcut "b" (before) and "a" (ahead). Dbus support is present (but untested). 
Open Points: 
  * there is still some noise between the audio files
  * for videos, the black background isn't kept
  * on purpose, I didn't changed the indentation in omxplayer.cpp inside the while-loop to facilitate the comparison. This could be done by me or after merging

I would like that the changes are reviewed and, if applicable, merged.

Thanks,

Chris (from FreeMind)