### PR TITLE
Changes needed for Falcon Pi Player

### DIFF
--- a/KeyConfig.cpp
+++ b/KeyConfig.cpp
@@ -100,6 +100,9 @@ map<int, int> KeyConfig::buildDefaultKeymap()
 
     keymap['1'] = ACTION_DECREASE_SPEED;
     keymap['2'] = ACTION_INCREASE_SPEED;
+    keymap['8'] = ACTION_DECREASE_SPEED_MICRO;
+    keymap['9'] = ACTION_NORMAL_SPEED;
+    keymap['0'] = ACTION_INCREASE_SPEED_MICRO;
     keymap['<'] = ACTION_REWIND;
     keymap[','] = ACTION_REWIND;
     keymap['>'] = ACTION_FAST_FORWARD;

--- a/KeyConfig.h
+++ b/KeyConfig.h
@@ -40,7 +40,10 @@ class KeyConfig
         ACTION_SHOW_SUBTITLES = 31,
         ACTION_SET_ALPHA = 32,
         ACTION_SET_ASPECT_MODE = 33,
-        ACTION_CROP_VIDEO = 34
+        ACTION_CROP_VIDEO = 34,
+        ACTION_DECREASE_SPEED_MICRO = 35,
+        ACTION_NORMAL_SPEED = 36,
+        ACTION_INCREASE_SPEED_MICRO = 37
     };
 
     #define KEY_LEFT 0x5b44


### PR DESCRIPTION
The MultiSync Video support required minor changes to the omxplayer binary.
These changes include:

- Fixing a speed-adjustment bug
- Adding new commands for fine-grained speed control necessary for syncing
  video running on multiple Pi units across a network.
- Adding a "-V" verbose option to increase the status output frequency to
  occur more often to allow for tighter sync between multiple Pi's.