### PR TITLE
DBus support improvment according to MPRIS2 specifications

### DIFF
--- a/KeyConfig.h
+++ b/KeyConfig.h
@@ -22,7 +22,7 @@ class KeyConfig
         ACTION_DECREASE_SUBTITLE_DELAY = 13,
         ACTION_INCREASE_SUBTITLE_DELAY = 14,
         ACTION_EXIT = 15,
-        ACTION_PAUSE = 16,
+        ACTION_PLAYPAUSE = 16,
         ACTION_DECREASE_VOLUME = 17,
         ACTION_INCREASE_VOLUME = 18,
         ACTION_SEEK_BACK_SMALL = 19,
@@ -40,7 +40,9 @@ class KeyConfig
         ACTION_SHOW_SUBTITLES = 31,
         ACTION_SET_ALPHA = 32,
         ACTION_SET_ASPECT_MODE = 33,
-        ACTION_CROP_VIDEO = 34
+        ACTION_CROP_VIDEO = 34,
+        ACTION_PAUSE = 35,
+        ACTION_PLAY = 36,
     };
 
     #define KEY_LEFT 0x5b44

--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -13,6 +13,47 @@
 #include "OMXControl.h"
 #include "KeyConfig.h"
 
+
+void ToURI(const std::string& str, char *uri)
+{
+  //Test if URL/URI
+  bool isURL=true;
+  auto result = str.find("://");
+  if(result == std::string::npos || result == 0)
+  {
+    isURL=false;
+  }
+  
+  if(isURL)
+  {
+    for(size_t i = 0; i < result; ++i)
+    {
+      if(!isalpha(str[i]))
+        isURL=false;
+    }
+  }
+  
+  //Build URI if needed
+  if(isURL)
+  {
+    //Just write URL as it is
+    strncpy(uri, str.c_str(), PATH_MAX);
+  }
+  else
+  {
+    //Get file full path and add file://
+    char * real_path=realpath(str.c_str(), NULL);
+    sprintf(uri, "file://%s", real_path);
+    free(real_path);
+  }
+}
+
+void deprecatedMessage()
+{
+  CLog::Log(LOGWARNING, "DBus property access through direct method is deprecated. Use Get/Set methods instead.");
+}
+
+
 #define CLASSNAME "OMXControl"
 
 OMXControlResult::OMXControlResult( int newKey ) {
@@ -159,15 +200,383 @@ OMXControlResult OMXControl::getEvent()
 
   CLog::Log(LOGDEBUG, "Popped message member: %s interface: %s type: %d path: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m) );
 
+
+  //----------------------------DBus root interface-----------------------------
+  //Methods:
   if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_ROOT, "Quit"))
   {
-    dbus_respond_ok(m);
+    dbus_respond_ok(m);//Note: No reply according to MPRIS2 specs
     return KeyConfig::ACTION_EXIT;
   }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_ROOT, "Raise"))
+  {
+    //Does nothing
+    return KeyConfig::ACTION_BLANK;
+  }
+  //Properties Get method:
+  //TODO: implement GetAll
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Get"))
+  {
+    DBusError error;
+    dbus_error_init(&error);
+
+    //Retrieve interface and property name
+    const char *interface, *property;
+    dbus_message_get_args(m, &error, DBUS_TYPE_STRING, &interface, DBUS_TYPE_STRING, &property, DBUS_TYPE_INVALID);
+    //Root interface:
+    if (strcmp(interface, OMXPLAYER_DBUS_INTERFACE_ROOT)==0)
+    {
+      if (strcmp(property, "CanRaise")==0)
+      {
+        dbus_respond_boolean(m, 0);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "CanQuit")==0)
+      {
+        dbus_respond_boolean(m, 1);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "CanSetFullscreen")==0)
+      {
+        dbus_respond_boolean(m, 0);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "Fullscreen")==0) //Fullscreen is read/write in theory not read only, but read only at the moment so...
+      {
+        dbus_respond_boolean(m, 1);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "HasTrackList")==0)
+      {
+        dbus_respond_boolean(m, 0);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "Identity")==0)
+      {
+        dbus_respond_string(m, "OMXPlayer");
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "SupportedUriSchemes")==0) //TODO: Update ?
+      {
+        const char *UriSchemes[] = {"file", "http", "rtsp", "rtmp"};
+        dbus_respond_array(m, UriSchemes, 4); // Array is of length 4
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "SupportedMimeTypes")==0) //Vinc: TODO: Minimal list of supported types based on ffmpeg minimal support ?
+      {
+        const char *MimeTypes[] = {}; // Needs supplying
+        dbus_respond_array(m, MimeTypes, 0);
+        return KeyConfig::ACTION_BLANK;
+      }
+      //Wrong property
+      else
+      {
+        //Error
+        CLog::Log(LOGWARNING, "Unhandled dbus property message, member: %s interface: %s type: %d path: %s property: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m), property );
+        return KeyConfig::ACTION_BLANK;
+      }
+    }
+    //Player interface:
+    else if (strcmp(interface, OMXPLAYER_DBUS_INTERFACE_PLAYER)==0)
+    {
+      //MPRIS2 properties:
+      if (strcmp(property, "CanGoNext")==0)
+      {
+        dbus_respond_boolean(m, 0);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "CanGoPrevious")==0)
+      {
+        dbus_respond_boolean(m, 0);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "CanSeek")==0)
+      {
+        dbus_respond_boolean(m, reader->CanSeek());
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "CanControl")==0)
+      {
+        dbus_respond_boolean(m, 1);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "CanPlay")==0)
+      {
+        dbus_respond_boolean(m, 1);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "CanPause")==0)
+      {
+        dbus_respond_boolean(m, 1);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "Position")==0)
+      {
+        // Returns the current position in microseconds
+        int64_t pos = clock->OMXMediaTime();
+        dbus_respond_int64(m, pos);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "PlaybackStatus")==0)
+      {
+        const char *status;
+        if (clock->OMXIsPaused())
+        {
+          status = "Paused";
+        }
+        else
+        {
+          status = "Playing";
+        }
+        dbus_respond_string(m, status);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "MinimumRate")==0)
+      {
+        dbus_respond_double(m, (MIN_RATE)/1000.);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "MaximumRate")==0)
+      {
+        dbus_respond_double(m, (MAX_RATE)/1000.);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "Rate")==0)
+      {
+        //return current playing rate
+        dbus_respond_double(m, (double)clock->OMXPlaySpeed()/1000.);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "Volume")==0)
+      {
+        //return current volume
+        dbus_respond_double(m, audio->GetVolume());
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "Metadata")==0)
+      {
+        DBusMessage *reply;
+        reply = dbus_message_new_method_return(m);
+        if(reply)
+        {
+          //Create iterator: Array of dict entries, composed of string (key)) and variant (value)
+          DBusMessageIter array_cont, dict_cont, dict_entry_cont, var;
+          dbus_message_iter_init_append(reply, &array_cont);
+          dbus_message_iter_open_container(&array_cont, DBUS_TYPE_ARRAY, "{sv}", &dict_cont);
+            //First dict entry: URI
+            const char *key1 = "xesam:url";
+            char uri[PATH_MAX+7];
+            ToURI(reader->getFilename(), uri);
+            const char *value1=uri;
+            dbus_message_iter_open_container(&dict_cont, DBUS_TYPE_DICT_ENTRY, NULL, &dict_entry_cont);
+              dbus_message_iter_append_basic(&dict_entry_cont, DBUS_TYPE_STRING, &key1);
+              dbus_message_iter_open_container(&dict_entry_cont, DBUS_TYPE_VARIANT, DBUS_TYPE_STRING_AS_STRING, &var);
+              dbus_message_iter_append_basic(&var, DBUS_TYPE_STRING, &value1);
+              dbus_message_iter_close_container(&dict_entry_cont, &var);
+            dbus_message_iter_close_container(&dict_cont, &dict_entry_cont);
+            //Second dict entry: duration in us
+            const char *key2 = "mpris:length";
+            dbus_int64_t value2 = reader->GetStreamLength()*1000;
+            reader->GetStreamLength();
+            dbus_message_iter_open_container(&dict_cont, DBUS_TYPE_DICT_ENTRY, NULL, &dict_entry_cont);
+              dbus_message_iter_append_basic(&dict_entry_cont, DBUS_TYPE_STRING, &key2);
+              dbus_message_iter_open_container(&dict_entry_cont, DBUS_TYPE_VARIANT, DBUS_TYPE_INT64_AS_STRING, &var);
+              dbus_message_iter_append_basic(&var, DBUS_TYPE_INT64, &value2);
+              dbus_message_iter_close_container(&dict_entry_cont, &var);
+            dbus_message_iter_close_container(&dict_cont, &dict_entry_cont);
+          dbus_message_iter_close_container(&array_cont, &dict_cont);
+          //Send message
+          dbus_connection_send(bus, reply, NULL);
+          dbus_message_unref(reply);
+        }
+        return KeyConfig::ACTION_BLANK;
+      }
+      
+      //Non-MPRIS2 properties:
+      else if (strcmp(property, "Aspect")==0)
+      {
+        // Returns aspect ratio
+        double ratio = reader->GetAspectRatio();
+        dbus_respond_double(m, ratio);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "VideoStreamCount")==0)
+      {
+        // Returns number of video streams
+        int64_t vcount = reader->VideoStreamCount();
+        dbus_respond_int64(m, vcount);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "ResWidth")==0)
+      {
+        // Returns width of video
+        int64_t width = reader->GetWidth();
+        dbus_respond_int64(m, width);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "ResHeight")==0)
+      {
+        // Returns height of video
+        int64_t height = reader->GetHeight();
+        dbus_respond_int64(m, height);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property,  "Duration")==0)
+      {
+        // Returns the duration in microseconds
+        int64_t dur = reader->GetStreamLength();
+        dur *= 1000; // ms -> us
+        dbus_respond_int64(m, dur);
+        return KeyConfig::ACTION_BLANK;
+      }
+      //Wrong property
+      else
+      {
+        //Error
+        CLog::Log(LOGWARNING, "Unhandled dbus property message, member: %s interface: %s type: %d path: %s  property: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m), property );
+        return KeyConfig::ACTION_BLANK;
+      }
+    }
+    //Wrong interface:
+    else
+    {
+        //Error
+        CLog::Log(LOGWARNING, "Unhandled dbus message, member: %s interface: %s type: %d path: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m) );
+        return KeyConfig::ACTION_BLANK;
+    }
+  }
+  //Properties Set method:
+  //TODO: implement signal generation on some property changes
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Set"))
+  {
+    DBusError error;
+    dbus_error_init(&error);
+
+    //Retrieve interface, property name and value
+    //Message has the form message[STRING:interface STRING:property DOUBLE:value] or message[STRING:interface STRING:property VARIANT[DOUBLE:value]]
+    const char *interface, *property;
+    double new_property_value;
+    DBusMessageIter args;
+    dbus_message_iter_init(m, &args);
+    if(dbus_message_iter_has_next(&args))
+    {
+		//The interface name
+		if( DBUS_TYPE_STRING == dbus_message_iter_get_arg_type(&args) ) 
+			dbus_message_iter_get_basic (&args, &interface);
+		else
+		{
+			printf("setE1\n");
+			CLog::Log(LOGWARNING, "Unhandled dbus message, member: %s interface: %s type: %d path: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m) );
+			dbus_error_free(&error);
+			return KeyConfig::ACTION_BLANK;
+		}
+		//The property name
+		if( dbus_message_iter_next(&args) && DBUS_TYPE_STRING == dbus_message_iter_get_arg_type(&args) )
+			dbus_message_iter_get_basic (&args, &property);
+		else
+		{
+			CLog::Log(LOGWARNING, "Unhandled dbus message, member: %s interface: %s type: %d path: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m) );
+			dbus_error_free(&error);
+			return KeyConfig::ACTION_BLANK;
+		}
+		//The value (either double or double in variant)
+		if (dbus_message_iter_next(&args))
+		{
+			//Simply a double
+			if (DBUS_TYPE_DOUBLE == dbus_message_iter_get_arg_type(&args))
+			{
+				dbus_message_iter_get_basic(&args, &new_property_value);
+			}
+			//A double within a variant
+			else if(DBUS_TYPE_VARIANT == dbus_message_iter_get_arg_type(&args))
+			{
+				DBusMessageIter variant;
+				dbus_message_iter_recurse(&args, &variant);
+				if(DBUS_TYPE_DOUBLE == dbus_message_iter_get_arg_type(&variant))
+				{
+					dbus_message_iter_get_basic(&variant, &new_property_value);
+				}
+			}
+			else
+			{
+				CLog::Log(LOGWARNING, "Unhandled dbus message, member: %s interface: %s type: %d path: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m) );
+				dbus_error_free(&error);
+				return KeyConfig::ACTION_BLANK;
+			}
+		}
+	}
+    if ( dbus_error_is_set(&error) )
+    {
+        CLog::Log(LOGWARNING, "Unhandled dbus message, member: %s interface: %s type: %d path: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m) );
+        dbus_error_free(&error);
+        return KeyConfig::ACTION_BLANK;
+    }
+    //Player interface:
+    if (strcmp(interface, OMXPLAYER_DBUS_INTERFACE_PLAYER)==0)
+    {
+      if (strcmp(property, "Volume")==0)
+      {
+        double volume=new_property_value;
+        //Min value is 0
+        if(volume<.0)
+        {
+          volume=.0;
+        }
+        audio->SetVolume(volume);
+        dbus_respond_double(m, volume);
+        return KeyConfig::ACTION_BLANK;
+      }
+      else if (strcmp(property, "Rate")==0)
+      {
+        double rate=new_property_value;
+        if(rate>MAX_RATE/1000.)
+        {
+          rate=MAX_RATE/1000.;
+        }
+        if(rate<MIN_RATE/1000.)
+        {
+          //Set to Pause according to MPRIS2 specs (no actual change of playing rate)
+          dbus_respond_double(m, (double)clock->OMXPlaySpeed()/1000.);
+          return KeyConfig::ACTION_PAUSE;
+        }
+        int iSpeed=(int)(rate*1000.);
+        if(!clock)
+        {
+          dbus_respond_double(m, .0);//What value ????
+          return KeyConfig::ACTION_BLANK;
+        }
+        //Can't do trickplay here so limit max speed
+        if(iSpeed > MAX_RATE)
+          iSpeed=MAX_RATE;
+        dbus_respond_double(m, iSpeed/1000.);//Reply before applying to be faster
+        clock->OMXSetSpeed(iSpeed, false, true);
+        return KeyConfig::ACTION_PLAY;
+      }
+      //Wrong property
+      else
+      {
+        //Error
+        CLog::Log(LOGWARNING, "Unhandled dbus property message, member: %s interface: %s type: %d path: %s  property: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m), property );
+        return KeyConfig::ACTION_BLANK;
+      }
+    }
+    //Wrong interface:
+    else
+    {
+        //Error
+        CLog::Log(LOGWARNING, "Unhandled dbus message, member: %s interface: %s type: %d path: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m) );
+        return KeyConfig::ACTION_BLANK;
+    }
+  }
+  //----------------------------------------------------------------------------
+
+
+  //-------------------------DEPRECATED PROPERTIES METHODS----------------------
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "CanQuit")
       || dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Fullscreen"))
   {
     dbus_respond_boolean(m, 1);
+    deprecatedMessage();
     return KeyConfig::ACTION_BLANK;
   }
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "CanSetFullscreen")
@@ -175,34 +584,40 @@ OMXControlResult OMXControl::getEvent()
       || dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "HasTrackList"))
   {
     dbus_respond_boolean(m, 0);
+    deprecatedMessage();
     return KeyConfig::ACTION_BLANK;
   }
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Identity"))
   {
     dbus_respond_string(m, "OMXPlayer");
+    deprecatedMessage();
     return KeyConfig::ACTION_BLANK;
   }
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "SupportedUriSchemes"))
   {
-    const char *UriSchemes[] = {"file", "http"};
+    const char *UriSchemes[] = {"file", "http", "rtsp", "rtmp"};
     dbus_respond_array(m, UriSchemes, 2); // Array is of length 2
+    deprecatedMessage();
     return KeyConfig::ACTION_BLANK;
   }
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "SupportedMimeTypes"))
   {
     const char *MimeTypes[] = {}; // Needs supplying
     dbus_respond_array(m, MimeTypes, 0);
+    deprecatedMessage();
     return KeyConfig::ACTION_BLANK;
   }
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "CanGoNext")
         || dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "CanGoPrevious"))
   {
     dbus_respond_boolean(m, 0);
+    deprecatedMessage();
     return KeyConfig::ACTION_BLANK;
   }
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "CanSeek"))
   {
     dbus_respond_boolean(m, reader->CanSeek());
+    deprecatedMessage();
     return KeyConfig::ACTION_BLANK;
   }
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "CanControl")
@@ -210,6 +625,143 @@ OMXControlResult OMXControl::getEvent()
         || dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "CanPause"))
   {
     dbus_respond_boolean(m, 1);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "PlaybackStatus"))
+  {
+    const char *status;
+    if (clock->OMXIsPaused())
+    {
+      status = "Paused";
+    }
+    else
+    {
+      status = "Playing";
+    }
+
+    dbus_respond_string(m, status);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "GetSource"))
+  {
+    dbus_respond_string(m, reader->getFilename().c_str());
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Volume"))
+  {
+    DBusError error;
+    dbus_error_init(&error);
+
+    double volume;
+    dbus_message_get_args(m, &error, DBUS_TYPE_DOUBLE, &volume, DBUS_TYPE_INVALID);
+
+    if (dbus_error_is_set(&error))
+    { // i.e. Get current volume
+      dbus_error_free(&error);
+      dbus_respond_double(m, audio->GetVolume());
+      deprecatedMessage();
+      return KeyConfig::ACTION_BLANK;
+    }
+    else
+    {
+      //Min value is 0
+      if(volume<.0)
+      {
+        volume=.0;
+      }
+      audio->SetVolume(volume);
+      dbus_respond_double(m, volume);
+      deprecatedMessage();
+      return KeyConfig::ACTION_BLANK;
+    }
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Mute"))
+  {
+    audio->SetMute(true);
+    dbus_respond_ok(m);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Unmute"))
+  {
+    audio->SetMute(false);
+    dbus_respond_ok(m);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Position"))
+  {
+    // Returns the current position in microseconds
+    int64_t pos = clock->OMXMediaTime();
+    dbus_respond_int64(m, pos);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Aspect"))
+  {
+    // Returns aspect ratio
+    double ratio = reader->GetAspectRatio();
+    dbus_respond_double(m, ratio);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "VideoStreamCount"))
+  {
+    // Returns number of video streams
+    int64_t vcount = reader->VideoStreamCount();
+    dbus_respond_int64(m, vcount);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "ResWidth"))
+  {
+    // Returns width of video
+    int64_t width = reader->GetWidth();
+    dbus_respond_int64(m, width);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "ResHeight"))
+  {
+    // Returns height of video
+    int64_t height = reader->GetHeight();
+    dbus_respond_int64(m, height);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Duration"))
+  {
+    // Returns the duration in microseconds
+    int64_t dur = reader->GetStreamLength();
+    dur *= 1000; // ms -> us
+    dbus_respond_int64(m, dur);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "MinimumRate"))
+  {
+    dbus_respond_double(m, 0.0);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "MaximumRate"))
+  {
+    //TODO: to be made consistent
+    dbus_respond_double(m, 10.125);
+    deprecatedMessage();
+    return KeyConfig::ACTION_BLANK;
+  }
+  //----------------------------------------------------------------------------
+
+
+  //--------------------------Player interface methods--------------------------
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "GetSource"))
+  {
+    dbus_respond_string(m, reader->getFilename().c_str());
+    return KeyConfig::ACTION_BLANK;
   }
   else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "Next"))
   {
@@ -221,11 +773,20 @@ OMXControlResult OMXControl::getEvent()
     dbus_respond_ok(m);
     return KeyConfig::ACTION_PREVIOUS_CHAPTER;
   }
-  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "Pause")
-        || dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "PlayPause"))
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "Pause"))
   {
     dbus_respond_ok(m);
     return KeyConfig::ACTION_PAUSE;
+  }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "Play"))
+  {
+    dbus_respond_ok(m);
+    return KeyConfig::ACTION_PLAY;
+  }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "PlayPause"))
+  {
+    dbus_respond_ok(m);
+    return KeyConfig::ACTION_PLAYPAUSE;
   }
   else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "Stop"))
   {
@@ -243,197 +804,97 @@ OMXControlResult OMXControl::getEvent()
     // Make sure a value is sent for seeking
     if (dbus_error_is_set(&error))
     {
-          CLog::Log(LOGWARNING, "Seek D-Bus Error: %s", error.message );
-          dbus_error_free(&error);
-          dbus_respond_ok(m);
-          return KeyConfig::ACTION_BLANK;
+       CLog::Log(LOGWARNING, "Seek D-Bus Error: %s", error.message );
+       dbus_error_free(&error);
+       dbus_respond_ok(m);
+       return KeyConfig::ACTION_BLANK;
     }
     else
     {
-          dbus_respond_int64(m, offset);
-          return OMXControlResult(KeyConfig::ACTION_SEEK_RELATIVE, offset);
+       dbus_respond_int64(m, offset);
+       return OMXControlResult(KeyConfig::ACTION_SEEK_RELATIVE, offset);
     }
   }
   else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "SetPosition"))
-    {
-      DBusError error;
-      dbus_error_init(&error);
-
-      int64_t position;
-      const char *oPath; // ignoring path right now because we don't have a playlist
-      dbus_message_get_args(m, &error, DBUS_TYPE_OBJECT_PATH, &oPath, DBUS_TYPE_INT64, &position, DBUS_TYPE_INVALID);
-
-      // Make sure a value is sent for setting position
-      if (dbus_error_is_set(&error))
-      {
-            CLog::Log(LOGWARNING, "SetPosition D-Bus Error: %s", error.message );
-            dbus_error_free(&error);
-            dbus_respond_ok(m);
-            return KeyConfig::ACTION_BLANK;
-      }
-      else
-      {
-            dbus_respond_int64(m, position);
-            return OMXControlResult(KeyConfig::ACTION_SEEK_ABSOLUTE, position);
-      }
-    }
-
-  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "SetAlpha"))
-    {
-      DBusError error;
-      dbus_error_init(&error);
-
-      int64_t alpha;
-      const char *oPath; // ignoring path right now because we don't have a playlist
-      dbus_message_get_args(m, &error, DBUS_TYPE_OBJECT_PATH, &oPath, DBUS_TYPE_INT64, &alpha, DBUS_TYPE_INVALID);
-
-      // Make sure a value is sent for setting alpha
-      if (dbus_error_is_set(&error))
-      {
-            CLog::Log(LOGWARNING, "SetAlpha D-Bus Error: %s", error.message );
-            dbus_error_free(&error);
-            dbus_respond_ok(m);
-            return KeyConfig::ACTION_BLANK;
-      }
-      else
-      {
-            dbus_respond_int64(m, alpha);
-            return OMXControlResult(KeyConfig::ACTION_SET_ALPHA, alpha);
-      }
-    }
-
-  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "SetAspectMode"))
-    {
-      DBusError error;
-      dbus_error_init(&error);
-
-      const char *aspectMode;
-      const char *oPath; // ignoring path right now because we don't have a playlist
-      dbus_message_get_args(m, &error, DBUS_TYPE_OBJECT_PATH, &oPath, DBUS_TYPE_STRING, &aspectMode, DBUS_TYPE_INVALID);
-
-      // Make sure a value is sent for setting aspect mode
-      if (dbus_error_is_set(&error))
-      {
-            CLog::Log(LOGWARNING, "SetAspectMode D-Bus Error: %s", error.message );
-            dbus_error_free(&error);
-            dbus_respond_ok(m);
-            return KeyConfig::ACTION_BLANK;
-      }
-      else
-      {
-            dbus_respond_string(m, aspectMode);
-            return OMXControlResult(KeyConfig::ACTION_SET_ASPECT_MODE, aspectMode);
-      }
-    }
-
-
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "PlaybackStatus"))
-  {
-    const char *status;
-    if (clock->OMXIsPaused())
-    {
-      status = "Paused";
-    }
-    else
-    {
-      status = "Playing";
-    }
-
-    dbus_respond_string(m, status);
-    return KeyConfig::ACTION_BLANK;
-  }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "GetSource"))
-  {
-    dbus_respond_string(m, reader->getFilename().c_str());
-    return KeyConfig::ACTION_BLANK;
-  }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Volume"))
   {
     DBusError error;
     dbus_error_init(&error);
 
-    double volume;
-    dbus_message_get_args(m, &error, DBUS_TYPE_DOUBLE, &volume, DBUS_TYPE_INVALID);
+    int64_t position;
+    const char *oPath; // ignoring path right now because we don't have a playlist
+    dbus_message_get_args(m, &error, DBUS_TYPE_OBJECT_PATH, &oPath, DBUS_TYPE_INT64, &position, DBUS_TYPE_INVALID);
 
+    // Make sure a value is sent for setting position
     if (dbus_error_is_set(&error))
-    { // i.e. Get current volume
+    {
+      CLog::Log(LOGWARNING, "SetPosition D-Bus Error: %s", error.message );
       dbus_error_free(&error);
-      dbus_respond_double(m, audio->GetVolume());
+      dbus_respond_ok(m);
       return KeyConfig::ACTION_BLANK;
     }
     else
     {
-      audio->SetVolume(volume);
-      dbus_respond_double(m, volume);
-      return KeyConfig::ACTION_BLANK;
+      dbus_respond_int64(m, position);
+      return OMXControlResult(KeyConfig::ACTION_SEEK_ABSOLUTE, position);
     }
   }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Mute"))
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "SetAlpha"))
+  {
+    DBusError error;
+    dbus_error_init(&error);
+
+    int64_t alpha;
+    const char *oPath; // ignoring path right now because we don't have a playlist
+    dbus_message_get_args(m, &error, DBUS_TYPE_OBJECT_PATH, &oPath, DBUS_TYPE_INT64, &alpha, DBUS_TYPE_INVALID);
+
+    // Make sure a value is sent for setting alpha
+    if (dbus_error_is_set(&error))
+    {
+      CLog::Log(LOGWARNING, "SetAlpha D-Bus Error: %s", error.message );
+      dbus_error_free(&error);
+      dbus_respond_ok(m);
+      return KeyConfig::ACTION_BLANK;
+    }
+    else
+    {
+      dbus_respond_int64(m, alpha);
+      return OMXControlResult(KeyConfig::ACTION_SET_ALPHA, alpha);
+    }
+  }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "SetAspectMode"))
+  {
+    DBusError error;
+    dbus_error_init(&error);
+
+    const char *aspectMode;
+    const char *oPath; // ignoring path right now because we don't have a playlist
+    dbus_message_get_args(m, &error, DBUS_TYPE_OBJECT_PATH, &oPath, DBUS_TYPE_STRING, &aspectMode, DBUS_TYPE_INVALID);
+
+    // Make sure a value is sent for setting aspect mode
+    if (dbus_error_is_set(&error))
+    {
+      CLog::Log(LOGWARNING, "SetAspectMode D-Bus Error: %s", error.message );
+      dbus_error_free(&error);
+      dbus_respond_ok(m);
+      return KeyConfig::ACTION_BLANK;
+    }
+    else
+    {
+      dbus_respond_string(m, aspectMode);
+      return OMXControlResult(KeyConfig::ACTION_SET_ASPECT_MODE, aspectMode);
+    }
+  }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "Mute"))
   {
     audio->SetMute(true);
     dbus_respond_ok(m);
     return KeyConfig::ACTION_BLANK;
   }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Unmute"))
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "Unmute"))
   {
     audio->SetMute(false);
     dbus_respond_ok(m);
     return KeyConfig::ACTION_BLANK;
-  }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Position"))
-  {
-    // Returns the current position in microseconds
-    int64_t pos = clock->OMXMediaTime();
-    dbus_respond_int64(m, pos);
-    return KeyConfig::ACTION_BLANK;
-  }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Aspect"))
-  {
-    // Returns aspect ratio
-    double ratio = reader->GetAspectRatio();
-    dbus_respond_double(m, ratio);
-    return KeyConfig::ACTION_BLANK;
-  }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "VideoStreamCount"))
-  {
-    // Returns number of video streams
-    int64_t vcount = reader->VideoStreamCount();
-    dbus_respond_int64(m, vcount);
-    return KeyConfig::ACTION_BLANK;
-  }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "ResWidth"))
-  {
-    // Returns width of video
-    int64_t width = reader->GetWidth();
-    dbus_respond_int64(m, width);
-    return KeyConfig::ACTION_BLANK;
-  }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "ResHeight"))
-  {
-    // Returns height of video
-    int64_t height = reader->GetHeight();
-    dbus_respond_int64(m, height);
-    return KeyConfig::ACTION_BLANK;
-  }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Duration"))
-  {
-    // Returns the duration in microseconds
-    int64_t dur = reader->GetStreamLength();
-    dur *= 1000; // ms -> us
-    dbus_respond_int64(m, dur);
-    return KeyConfig::ACTION_BLANK;
-  }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "MinimumRate"))
-  {
-    dbus_respond_double(m, 0.0);
-    return KeyConfig::ACTION_BLANK;
-  }
-  else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "MaximumRate"))
-  {
-    dbus_respond_double(m, 1.125);
-    return KeyConfig::ACTION_BLANK;
-
-    // Implement extra OMXPlayer controls
   }
   else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "ListSubtitles"))
   {
@@ -647,6 +1108,7 @@ OMXControlResult OMXControl::getEvent()
       return action; // Directly return enum
     }
   }
+  //----------------------------------------------------------------------------
   else {
     CLog::Log(LOGWARNING, "Unhandled dbus message, member: %s interface: %s type: %d path: %s", dbus_message_get_member(m), dbus_message_get_interface(m), dbus_message_get_type(m), dbus_message_get_path(m) );
   }

--- a/OMXControl.h
+++ b/OMXControl.h
@@ -7,6 +7,11 @@
 #include "OMXPlayerAudio.h"
 #include "OMXPlayerSubtitles.h"
 
+
+#define MIN_RATE (1)
+#define MAX_RATE (4 * DVD_PLAYSPEED_NORMAL)
+
+
 class OMXControlResult {
   int key;
   int64_t arg;

--- a/OMXPlayerAudio.h
+++ b/OMXPlayerAudio.h
@@ -83,7 +83,7 @@ protected:
   void UnLockDecoder();
 private:
 public:
-  OMXPlayerAudio();
+   OMXPlayerAudio();
   ~OMXPlayerAudio();
   bool Open(OMXClock *av_clock, const OMXAudioConfig &config, OMXReader *omx_reader);
   bool Close();

--- a/README.md
+++ b/README.md
@@ -206,7 +206,11 @@ take a look at the supplied [dbuscontrol.sh](dbuscontrol.sh) file.
 The root interface is accessible under the name
 `org.mpris.MediaPlayer2`.
 
-#### Quit
+#### Methods
+
+Root interface methods can be accessed through `org.mpris.MediaPlayer2.MethodName`.
+
+##### Quit
 
 Stops the currently playing video.  This will cause the currently running
 omxplayer process to terminate.
@@ -215,12 +219,22 @@ omxplayer process to terminate.
 :-------------: | -------
  Return         | `null`
 
-### Properties Interface
+##### Raise
 
-The properties interface is accessible under the name
-`org.freedesktop.DBus.Properties`.
+No effect.
 
-#### CanQuit
+   Params       |   Type   
+:-------------: | -------
+ Return         | `null`
+
+#### Properties
+
+Root interface properties can be accessed through `org.freedesktop.DBus.Properties.Get` 
+and `org.freedesktop.DBus.Properties.Set` methods with the string
+`"org.mpris.MediaPlayer2"` as first argument and the string `"PropertyName"` as
+second argument.
+
+##### CanQuit (ro)
 
 Whether or not the player can quit.
 
@@ -228,7 +242,7 @@ Whether or not the player can quit.
 :-------------: | ---------
  Return         | `boolean`
 
-#### Fullscreen
+##### Fullscreen (ro)
 
 Whether or not the player can is fullscreen.
 
@@ -236,7 +250,7 @@ Whether or not the player can is fullscreen.
 :-------------: | ---------
  Return         | `boolean`
 
-#### CanSetFullscreen
+##### CanSetFullscreen (ro)
 
 Whether or not the player can set fullscreen.
 
@@ -244,7 +258,7 @@ Whether or not the player can set fullscreen.
 :-------------: | ---------
  Return         | `boolean`
 
-#### CanRaise
+##### CanRaise (ro)
 
 Whether the display window can be brought to the top of all the window.
 
@@ -252,7 +266,7 @@ Whether the display window can be brought to the top of all the window.
 :-------------: | ---------
  Return         | `boolean`
 
-#### HasTrackList
+##### HasTrackList (ro)
 
 Whether or not the player has a track list.
 
@@ -260,7 +274,7 @@ Whether or not the player has a track list.
 :-------------: | ---------
  Return         | `boolean`
 
-#### Identity
+##### Identity (ro)
 
 Name of the player.
 
@@ -268,7 +282,7 @@ Name of the player.
 :-------------: | --------
  Return         | `string`
 
-#### SupportedUriSchemes
+##### SupportedUriSchemes (ro)
 
 Playable URI formats.
 
@@ -276,7 +290,7 @@ Playable URI formats.
 :-------------: | ----------
  Return         | `string[]`
 
-#### SupportedMimeTypes
+##### SupportedMimeTypes (ro)
 
 Supported mime types.  **Note**: currently not implemented.
 
@@ -284,7 +298,217 @@ Supported mime types.  **Note**: currently not implemented.
 :-------------: | ----------
  Return         | `string[]`
 
-#### CanGoNext
+
+### Player Interface
+
+The player interface is accessible under the name
+`org.mpris.MediaPlayer2.Player`.
+
+#### Methods
+
+Player interface methods can be accessed through `org.mpris.MediaPlayer2.Player.MethodName`.
+
+##### Next
+
+Skip to the next chapter.
+
+   Params       |   Type
+:-------------: | -------
+ Return         | `null` 
+
+##### Previous
+
+Skip to the previous chapter.
+
+   Params       |   Type
+:-------------: | -------
+ Return         | `null` 
+
+##### Play
+
+Play the video. If the video is playing, it has no effect, if it is
+paused it will play from current position and if it is stopped it will
+play from the beginning.
+
+   Params       |   Type
+:-------------: | -------
+ Return         | `null` 
+
+##### Pause
+
+Pause the video. If the video is playing, it will be paused, if it is
+paused it will stay in pause (no effect).
+
+   Params       |   Type
+:-------------: | -------
+ Return         | `null` 
+
+##### PlayPause
+
+Toggles the play state.  If the video is playing, it will be paused, if it is
+paused it will start playing.
+
+   Params       |   Type
+:-------------: | -------
+ Return         | `null` 
+
+##### Stop
+
+Stops the video.
+
+   Params       |   Type
+:-------------: | -------
+ Return         | `null` 
+
+##### Seek
+
+Perform a *relative* seek, i.e. seek plus or minus a certain number of
+microseconds from the current position in the video.
+
+   Params       |   Type            | Description
+:-------------: | ----------------- | ---------------------------
+ 1              | `int64`           | Microseconds to seek
+ Return         | `null` or `int64` | If the supplied offset is invalid, `null` is returned, otherwise the offset (in microseconds) is returned
+
+##### SetPosition
+
+Seeks to a specific location in the file.  This is an *absolute* seek.
+
+   Params       |   Type            | Description
+:-------------: | ----------------- | ------------------------------------
+ 1              | `string`          | Path (not currently used)
+ 2              | `int64`           | Position to seek to, in microseconds
+ Return         | `null` or `int64` | If the supplied position is invalid, `null` is returned, otherwise the position (in microseconds) is returned
+
+##### Mute
+
+Mute the audio stream.  If the volume is already muted, this does nothing.
+
+   Params       |   Type
+:-------------: | -------
+ Return         | `null` 
+
+##### Unmute
+
+Unmute the audio stream.  If the stream is already unmuted, this does nothing.
+
+   Params       |   Type
+:-------------: | -------
+ Return         | `null` 
+
+##### ListSubtitles
+
+Returns a array of all known subtitles.  The length of the array is the number
+of subtitles.  Each item in the araay is a string in the following format:
+
+    <index>:<language>:<name>:<codec>:<active>
+
+Any of the fields may be blank, except for `index`.  `language` is the language
+code, such as `eng`, `chi`, `swe`, etc.  `name` is a description of the
+subtitle, such as `foreign parts` or `SDH`.  `codec` is the name of the codec
+used by the subtitle, sudh as `subrip`.  `active` is either the string `active`
+or an empty string.
+
+   Params       |   Type
+:-------------: | ----------
+ Return         | `string[]` 
+
+##### ListAudio
+
+Returns and array of all known audio streams.  The length of the array is the
+number of streams.  Each item in the array is a string in the following format:
+
+    <index>:<language>:<name>:<codec>:<active>
+
+See `ListSubtitles` for a description of what each of these fields means.  An
+example of a possible string is:
+
+    0:eng:DD 5.1:ac3:active
+
+   Params       |   Type
+:-------------: | ----------
+ Return         | `string[]` 
+
+##### ListVideo
+
+Returns and array of all known video streams.  The length of the array is the
+number of streams.  Each item in the array is a string in the following format:
+
+    <index>:<language>:<name>:<codec>:<active>
+
+See `ListSubtitles` for a description of what each of these fields means.  An
+example of a possible string is:
+
+    0:eng:x264:h264:active
+
+   Params       |   Type
+:-------------: | ----------
+ Return         | `string[]` 
+
+##### SelectSubtitle
+
+Selects the subtitle at a given index.
+
+   Params       |   Type    | Description
+:-------------: | ----------| ------------------------------------
+ 1              | `int32`   | Index of subtitle to select
+ Return         | `boolean` | Returns `true` if subtitle was selected, `false otherwise
+
+
+##### SelectAudio
+
+Selects the audio stream at a given index.
+
+   Params       |   Type    | Description
+:-------------: | ----------| ------------------------------------
+ 1              | `int32`   | Index of audio stream to select
+ Return         | `boolean` | Returns `true` if stream was selected, `false otherwise
+
+##### ShowSubtitles
+
+Turns on subtitles.
+
+   Params       |   Type 
+:-------------: | -------
+ Return         | `null` 
+
+##### HideSubtitles
+
+Turns off subtitles.
+
+   Params       |   Type 
+:-------------: | -------
+ Return         | `null` 
+ 
+##### GetSource
+
+The current file or stream that is being played.
+
+   Params       |   Type
+:-------------: | ---------
+ Return         | `string` 
+
+
+##### Action
+
+Execute a "keyboard" command.  For available codes, see
+[KeyConfig.h](KeyConfig.h).
+
+
+   Params       |   Type    | Description
+:-------------: | ----------| ------------------
+ 1              | `int32`   | Command to execute
+ Return         | `null`    | 
+
+
+#### Properties
+
+Player interface properties can be accessed through `org.freedesktop.DBus.Properties.Get` 
+and `org.freedesktop.DBus.Properties.Set` methods with the string
+`"org.mpris.MediaPlayer2"` as first argument and the string `"PropertyName"` as
+second argument.
+
+##### CanGoNext (ro)
 
 Whether or not the play can skip to the next track.
 
@@ -292,7 +516,7 @@ Whether or not the play can skip to the next track.
 :-------------: | ---------
  Return         | `boolean`
 
-#### CanGoPrevious
+##### CanGoPrevious (ro)
 
 Whether or not the player can skip to the previous track.
 
@@ -300,7 +524,7 @@ Whether or not the player can skip to the previous track.
 :-------------: | ---------
  Return         | `boolean`
 
-#### CanSeek
+##### CanSeek (ro)
 
 Whether or not the player can seek.
 
@@ -309,7 +533,7 @@ Whether or not the player can seek.
  Return         | `boolean`
 
 
-#### CanControl
+##### CanControl (ro)
 
 Whether or not the player can be controlled.
 
@@ -317,13 +541,13 @@ Whether or not the player can be controlled.
 :-------------: | ---------
  Return         | `boolean`
 
-#### CanPlay
+##### CanPlay (ro)
 
 Whether or not the player can play.
 
 Return type: `boolean`.
 
-#### CanPause
+##### CanPause (ro)
 
 Whether or not the player can pause.
 
@@ -331,7 +555,7 @@ Whether or not the player can pause.
 :-------------: | ---------
  Return         | `boolean`
 
-#### PlaybackStatus
+##### PlaybackStatus (ro)
 
 The current state of the player, either "Paused" or "Playing".
 
@@ -339,15 +563,7 @@ The current state of the player, either "Paused" or "Playing".
 :-------------: | ---------
  Return         | `string` 
 
-#### GetSource
-
-The current file or stream that is being played.
-
-   Params       |   Type
-:-------------: | ---------
- Return         | `string` 
-
-#### Volume
+##### Volume (rw)
 
 When called with an argument it will set the volume and return the current
 volume.  When called without an argument it will simply return the current
@@ -367,23 +583,7 @@ Millibels can be converted to/from acceptable values using the following:
 
 [MPRIS_volume]: http://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Simple-Type:Volume
 
-#### Mute
-
-Mute the audio stream.  If the volume is already muted, this does nothing.
-
-   Params       |   Type
-:-------------: | -------
- Return         | `null` 
-
-#### Unmute
-
-Unmute the audio stream.  If the stream is already unmuted, this does nothing.
-
-   Params       |   Type
-:-------------: | -------
- Return         | `null` 
-
-#### Position
+##### Position (ro)
 
 Returns the current position of the playing media.
 
@@ -391,16 +591,7 @@ Returns the current position of the playing media.
 :-------------: | --------- | --------------------------------
  Return         | `int64`   | Current position in microseconds
 
-#### Duration
-
-Returns the total length of the playing media.
-
-   Params       |   Type    | Description
-:-------------: | --------- | ----------------------------
- Return         | `int64`   | Total length in microseconds
-
-
-#### MinimumRate
+##### MinimumRate (ro)
 
 Returns the minimum playback rate of the video.
 
@@ -408,7 +599,7 @@ Returns the minimum playback rate of the video.
 :-------------: | -------
  Return         | `double` 
 
-#### MaximumRate
+##### MaximumRate (ro)
 
 Returns the maximum playback rate of the video.
 
@@ -416,159 +607,64 @@ Returns the maximum playback rate of the video.
 :-------------: | -------
  Return         | `double` 
 
+##### Rate (rw)
 
-### Player Interface
-
-
-#### Next
-
-Skip to the next chapter.
-
-   Params       |   Type
-:-------------: | -------
- Return         | `null` 
-
-#### Previous
-
-Skip to the previous chapter.
-
-   Params       |   Type
-:-------------: | -------
- Return         | `null` 
-
-#### Pause
-
-Toggles the play state.  If the video is playing, it will be paused, if it is
-paused it will start playing.
-
-   Params       |   Type
-:-------------: | -------
- Return         | `null` 
-
-#### PlayPause
-
-Same as the `Pause` method.
-
-#### Stop
-
-Stops the video.
-
-   Params       |   Type
-:-------------: | -------
- Return         | `null` 
-
-#### Seek
-
-Perform a *relative* seek, i.e. seek plus or minus a certain number of
-microseconds from the current position in the video.
-
-   Params       |   Type            | Description
-:-------------: | ----------------- | ---------------------------
- 1              | `int64`           | Microseconds to seek
- Return         | `null` or `int64` | If the supplied offset is invalid, `null` is returned, otherwise the offset (in microseconds) is returned
-
-#### SetPosition
-
-Seeks to a specific location in the file.  This is an *absolute* seek.
-
-   Params       |   Type            | Description
-:-------------: | ----------------- | ------------------------------------
- 1              | `string`          | Path (not currently used)
- 2              | `int64`           | Position to seek to, in microseconds
- Return         | `null` or `int64` | If the supplied position is invalid, `null` is returned, otherwise the position (in microseconds) is returned
-
-
-#### ListSubtitles
-
-Returns a array of all known subtitles.  The length of the array is the number
-of subtitles.  Each item in the araay is a string in the following format:
-
-    <index>:<language>:<name>:<codec>:<active>
-
-Any of the fields may be blank, except for `index`.  `language` is the language
-code, such as `eng`, `chi`, `swe`, etc.  `name` is a description of the
-subtitle, such as `foreign parts` or `SDH`.  `codec` is the name of the codec
-used by the subtitle, sudh as `subrip`.  `active` is either the string `active`
-or an empty string.
-
-   Params       |   Type
-:-------------: | ----------
- Return         | `string[]` 
-
-#### ListAudio
-
-Returns and array of all known audio streams.  The length of the array is the
-number of streams.  Each item in the array is a string in the following format:
-
-    <index>:<language>:<name>:<codec>:<active>
-
-See `ListSubtitles` for a description of what each of these fields means.  An
-example of a possible string is:
-
-    0:eng:DD 5.1:ac3:active
-
-   Params       |   Type
-:-------------: | ----------
- Return         | `string[]` 
-
-#### ListVideo
-
-Returns and array of all known video streams.  The length of the array is the
-number of streams.  Each item in the array is a string in the following format:
-
-    <index>:<language>:<name>:<codec>:<active>
-
-See `ListSubtitles` for a description of what each of these fields means.  An
-example of a possible string is:
-
-    0:eng:x264:h264:active
-
-   Params       |   Type
-:-------------: | ----------
- Return         | `string[]` 
-
-#### SelectSubtitle
-
-Selects the subtitle at a given index.
+When called with an argument it will set the playing rate and return the 
+current rate. When called without an argument it will simply return the
+current rate. Rate of 1.0 is the normal playing rate. A value of 2.0
+corresponds to two times faster than normal rate, a value of 0.5 corresponds
+to two times slower than the normal rate.
 
    Params       |   Type    | Description
-:-------------: | ----------| ------------------------------------
- 1              | `int32`   | Index of subtitle to select
- Return         | `boolean` | Returns `true` if subtitle was selected, `false otherwise
+:-------------:	| --------- | ---------------------------
+ 1 (optional)   | `double`  | Rate to set
+ Return         | `double`  | Current rate
 
+##### Metadata (ro)
 
-#### SelectAudio
-
-Selects the audio stream at a given index.
-
-   Params       |   Type    | Description
-:-------------: | ----------| ------------------------------------
- 1              | `int32`   | Index of audio stream to select
- Return         | `boolean` | Returns `true` if stream was selected, `false otherwise
-
-#### ShowSubtitles
-
-Turns on subtitles.
-
-   Params       |   Type 
-:-------------: | -------
- Return         | `null` 
-
-#### HideSubtitles
-
-Turns off subtitles.
-
-   Params       |   Type 
-:-------------: | -------
- Return         | `null` 
-
-#### Action
-
-Execute a "keyboard" command.  For available codes, see
-[KeyConfig.h](KeyConfig.h).
-
+Returns track information: URI and length.
 
    Params       |   Type    | Description
-:-------------: | ----------| ------------------
- 1              | `int32`   | Command to execute
- Return         | `null`    | 
+:-------------: | --------- | ----------------------------
+ Return         | `dict`    | Dictionnary entries with key:value pairs
+
+##### Aspect (ro)
+
+Returns the aspect ratio.
+
+   Params       |   Type    | Description
+:-------------: | --------- | ----------------------------
+ Return         | `double`  | Aspect ratio
+
+##### VideoStreamCount (ro)
+
+Returns the number of video streams.
+
+   Params       |   Type    | Description
+:-------------: | --------- | ----------------------------
+ Return         | `int64`   | Number of video streams
+
+##### ResWidth (ro)
+
+Returns video width
+
+   Params       |   Type    | Description
+:-------------: | --------- | ----------------------------
+ Return         | `int64`   | Video width in px
+
+##### ResHeight (ro)
+
+Returns video width
+
+   Params       |   Type    | Description
+:-------------: | --------- | ----------------------------
+ Return         | `int64`   | Video height in px
+
+##### Duration (ro)
+
+Returns the total length of the playing media.
+
+   Params       |   Type    | Description
+:-------------: | --------- | ----------------------------
+ Return         | `int64`   | Total length in microseconds
+

--- a/dbuscontrol.sh
+++ b/dbuscontrol.sh
@@ -11,15 +11,15 @@ export DBUS_SESSION_BUS_PID=`cat $OMXPLAYER_DBUS_PID`
 
 case $1 in
 status)
-	duration=`dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Duration`
+	duration=`dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:"org.mpris.MediaPlayer2.Player" string:"Duration"`
 	[ $? -ne 0 ] && exit 1
 	duration="$(awk '{print $2}' <<< "$duration")"
 
-	position=`dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Position`
+	position=`dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:"org.mpris.MediaPlayer2.Player" string:"Position"`
 	[ $? -ne 0 ] && exit 1
 	position="$(awk '{print $2}' <<< "$position")"
 
-	playstatus=`dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.PlaybackStatus`
+	playstatus=`dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:"org.mpris.MediaPlayer2.Player" string:"PlaybackStatus"`
 	[ $? -ne 0 ] && exit 1
 	playstatus="$(sed 's/^ *//;s/ *$//;' <<< "$playstatus")"
 
@@ -31,7 +31,7 @@ status)
 	;;
 
 volume)
-	volume=`dbus-send --print-reply=double --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Volume ${2:+double:}$2`
+	volume=`dbus-send --print-reply=double --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Set string:"org.mpris.MediaPlayer2.Player" string:"Volume" ${2:+double:}$2`
 	[ $? -ne 0 ] && exit 1
 	volume="$(awk '{print $2}' <<< "$volume")"
 	echo "Volume: $volume"
@@ -97,11 +97,11 @@ showsubtitles)
 	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:31 >/dev/null
 	;;
 getsource)
-	source=$(dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.GetSource)
+	source=$(dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.GetSource)
 	echo "$source" | sed 's/^ *//'
 	;;
 *)
-	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|togglesubtitles|hidesubtitles|showsubtitles|setvideopos [x1 y1 x2 y2]|setvideocroppos [x1 y1 x2 y2]|setaspectmode [letterbox,fill,stretch,default]|setalpha [alpha (0..255)]" >&2
+	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|togglesubtitles|hidesubtitles|showsubtitles|setvideopos [x1 y1 x2 y2]|setvideocroppos [x1 y1 x2 y2]|setaspectmode [letterbox,fill,stretch,default]|setalpha [alpha (0..255)]|getsource" >&2
 	exit 1
 	;;
 esac

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1414,7 +1414,21 @@ int main(int argc, char *argv[])
       case KeyConfig::ACTION_SET_ALPHA:
           m_player_video.SetAlpha(result.getArg());
           break;
+      case KeyConfig::ACTION_PLAY:
+        m_Pause=false;
+        if(m_has_subtitle)
+        {
+          m_player_subtitles.Resume();
+        }
+        break;
       case KeyConfig::ACTION_PAUSE:
+        m_Pause=true;
+        if(m_has_subtitle)
+        {
+          m_player_subtitles.Pause();
+        }
+        break;
+      case KeyConfig::ACTION_PLAYPAUSE:
         m_Pause = !m_Pause;
         if (m_av_clock->OMXPlaySpeed() != DVD_PLAYSPEED_NORMAL && m_av_clock->OMXPlaySpeed() != DVD_PLAYSPEED_PAUSE)
         {


### PR DESCRIPTION
Some changes to the DBus controller mainly to better respect the [MPRIS2 standard](http://specifications.freedesktop.org/mpris-spec/latest/).

Changes:
- All properties (accessible through `org.freedesktop.DBus.Properties`) are now actual properties (instead of methods) according to [MPRIS2 specifications](http://specifications.freedesktop.org/mpris-spec/latest/). See the updated README and dbuscontrol.sh for example.
- Differentiate Pause/PlayPause controls: now Pause only pause the player and has no effect if already paused. PlayPause remains unchanged.
- Mute, Unmute and GetSource are now methods on the player interface (`org.mpris.MediaPlayer2.Player`) (previously methods on the Properties interface).
- Add a minimalist Metadata property (URI and track length).
- Add rtsp and rtmp to the SupportedUriSchemes
- Add a 'Rate' property. Still need to be properly tested.