### PR TITLE
Add ability to set background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Usage: omxplayer [OPTIONS] [FILE]
     -r  --refresh               Adjust framerate/resolution to video
     -g  --genlog                Generate log file
     -l  --pos n                 Start position (hh:mm:ss)
-    -b  --blank                 Set background to black
+    -b  --blank                 Set the video background color to black (identical to --bg 000)
+        --bg rrggbb             Set the video background color to any RGB hex code (e.g. b955ff)
         --loop                  Loop file. Ignored if file not seekable
         --no-boost-on-downmix   Don't boost volume when downmixing
         --vol n                 set initial volume in millibels (default 0)


### PR DESCRIPTION
This pull request adds the argument `--bg` to omxplayer, which lets you specify a background color to use, unlike `--blank` which only lets you set a black background. It is completely backwards compatible.

Originally, I set out to implement an optional argument to `--blank` which specified the color (as mentioned in #424), but as it turns out that isn't a great idea. With an optional argument, things may break where what the user intended to be a filename turns into the color argument for `--blank`.

So, I changed things around again and moved the custom background color option to `--bg`, at which point I realized my changes were very similar to those in #376. The design and implementation in this pull request, however, have two important differences from the ones in #376:

* Unlike the #376 implementation's float tuples, this version uses hex codes (e.g. `#b955ff`), which:
    * Have higher familiarity among users
    * Give opportunity for exact precision
* This version uses `VC_IMAGE_RGBX32` instead of the previous `VC_IMAGE_RGB565`, which gives the user access to the entire color spectrum and not only a limited subset.

I found myself wanting a white background the other day, and I can think of at least a few situations where other colors could be useful or at the very least look better than black. 