### PR TITLE
Add new option "--lavfdopts" for passing key:value options to libavformat.

### DIFF
--- a/DllAvFormat.h
+++ b/DllAvFormat.h
@@ -90,6 +90,8 @@ public:
   virtual void avio_wb32(AVIOContext *s, unsigned int val)=0;
   virtual void avio_wb16(AVIOContext *s, unsigned int val)=0;
   virtual AVFormatContext *avformat_alloc_context(void)=0;
+  virtual int av_set_options_string(AVFormatContext *ctx, const char *opts,
+				    const char *key_val_sep, const char *pairs_sep)=0;
   virtual AVStream *avformat_new_stream(AVFormatContext *s, AVCodec *c)=0;
   virtual AVOutputFormat *av_guess_format(const char *short_name, const char *filename, const char *mime_type)=0;
   virtual int avformat_write_header (AVFormatContext *s, AVDictionary **options)=0;
@@ -144,6 +146,8 @@ public:
   virtual void avio_wb32(AVIOContext *s, unsigned int val) { ::avio_wb32(s, val); }
   virtual void avio_wb16(AVIOContext *s, unsigned int val) { ::avio_wb16(s, val); }
   virtual AVFormatContext *avformat_alloc_context() { return ::avformat_alloc_context(); }
+  virtual int av_set_options_string(AVFormatContext *ctx, const char *opts,
+				    const char *key_val_sep, const char *pairs_sep) { return ::av_set_options_string(ctx, opts, key_val_sep, pairs_sep); }
   virtual AVStream *avformat_new_stream(AVFormatContext *s, AVCodec *c) { return ::avformat_new_stream(s, c); }
   virtual AVOutputFormat *av_guess_format(const char *short_name, const char *filename, const char *mime_type) { return ::av_guess_format(short_name, filename, mime_type); }
   virtual int avformat_write_header (AVFormatContext *s, AVDictionary **options) { return ::avformat_write_header (s, options); }
@@ -199,6 +203,7 @@ class DllAvFormat : public DllDynamic, DllAvFormatInterface
   DEFINE_METHOD2(int, avio_close_dyn_buf, (AVIOContext *p1, uint8_t **p2))
   DEFINE_METHOD3(offset_t, avio_seek, (AVIOContext *p1, offset_t p2, int p3))
   DEFINE_METHOD0(AVFormatContext *, avformat_alloc_context)
+  DEFINE_METHOD4(int, av_set_options_string, (AVFormatContext *p1, const char *p2, const char *p3, const char *p4))
   DEFINE_METHOD2(AVStream *, avformat_new_stream, (AVFormatContext *p1, AVCodec *p2))
   DEFINE_METHOD3(AVOutputFormat *, av_guess_format, (const char *p1, const char *p2, const char *p3))
   DEFINE_METHOD2(int, avformat_write_header , (AVFormatContext *p1, AVDictionary **p2))
@@ -234,6 +239,7 @@ class DllAvFormat : public DllDynamic, DllAvFormatInterface
     RESOLVE_METHOD(avio_wb32)
     RESOLVE_METHOD(avio_wb16)
     RESOLVE_METHOD(avformat_alloc_context)
+    RESOLVE_METHOD(av_set_options_string)
     RESOLVE_METHOD(avformat_new_stream)
     RESOLVE_METHOD(av_guess_format)
     RESOLVE_METHOD(avformat_write_header)

--- a/OMXReader.cpp
+++ b/OMXReader.cpp
@@ -134,7 +134,7 @@ static offset_t dvd_file_seek(void *h, offset_t pos, int whence)
     return pFile->Seek(pos, whence & ~AVSEEK_FORCE);
 }
 
-bool OMXReader::Open(std::string filename, bool dump_format, bool live /* =false */, float timeout /* = 0.0f */, std::string cookie /* = "" */, std::string user_agent /* = "" */)
+bool OMXReader::Open(std::string filename, bool dump_format, bool live /* =false */, float timeout /* = 0.0f */, std::string cookie /* = "" */, std::string user_agent /* = "" */, std::string lavfdopts /* = "" */)
 {
   if (!m_dllAvUtil.Load() || !m_dllAvCodec.Load() || !m_dllAvFormat.Load())
     return false;
@@ -159,6 +159,15 @@ bool OMXReader::Open(std::string filename, bool dump_format, bool live /* =false
   unsigned int  flags     = READ_TRUNCATED | READ_BITRATE | READ_CHUNKED;
 
   m_pFormatContext     = m_dllAvFormat.avformat_alloc_context();
+
+  result = m_dllAvFormat.av_set_options_string(m_pFormatContext, lavfdopts.c_str(), ":", ",");
+
+  if (result < 0)
+  {
+    CLog::Log(LOGERROR, "COMXPlayer::OpenFile - invalid lavfdopts %s ", lavfdopts.c_str());
+    Close();
+    return false;
+  }
 
   // set the interrupt callback, appeared in libavformat 53.15.0
   m_pFormatContext->interrupt_callback = int_cb;

--- a/OMXReader.h
+++ b/OMXReader.h
@@ -132,7 +132,7 @@ private:
 public:
   OMXReader();
   ~OMXReader();
-  bool Open(std::string filename, bool dump_format, bool live = false, float timeout = 0.0f, std::string cookie = "", std::string user_agent = "");
+  bool Open(std::string filename, bool dump_format, bool live = false, float timeout = 0.0f, std::string cookie = "", std::string user_agent = "", std::string lavfdopts = "");
   void ClearStreams();
   bool Close();
   //void FlushRead();

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Usage: omxplayer [OPTIONS] [FILE]
         --display n             Set display to output to
         --cookie 'cookie'       Send specified cookie as part of HTTP requests
         --user-agent 'ua'       Send specified User-Agent as part of HTTP requests
+        --lavfdopts 'opts'      Options passed to libavformat, e.g. 'probesize:250000,...'
 
 For example:
 

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -526,6 +526,7 @@ int main(int argc, char *argv[])
   bool idle = false;
   std::string            m_cookie              = "";
   std::string            m_user_agent          = "";
+  std::string            m_lavfdopts           = "";
 
   const int font_opt        = 0x100;
   const int italic_font_opt = 0x201;
@@ -565,6 +566,7 @@ int main(int argc, char *argv[])
   const int crop_opt        = 0x213;
   const int http_cookie_opt = 0x300;
   const int http_user_agent_opt = 0x301;
+  const int lavfdopts_opt   = 0x400;
 
   struct option longopts[] = {
     { "info",         no_argument,        NULL,          'i' },
@@ -625,6 +627,7 @@ int main(int argc, char *argv[])
     { "display",      required_argument,  NULL,          display_opt },
     { "cookie",       required_argument,  NULL,          http_cookie_opt },
     { "user-agent",   required_argument,  NULL,          http_user_agent_opt },
+    { "lavfdopts",    required_argument,  NULL,          lavfdopts_opt },
     { 0, 0, 0, 0 }
   };
 
@@ -879,6 +882,9 @@ int main(int argc, char *argv[])
       case http_user_agent_opt:
         m_user_agent = optarg;
         break;    
+    case lavfdopts_opt:
+        m_lavfdopts = optarg;
+        break;
       case 0:
         break;
       case 'h':
@@ -998,7 +1004,7 @@ int main(int argc, char *argv[])
     m_keyboard->setDbusName(m_dbus_name);
   }
 
-  if(!m_omx_reader.Open(m_filename.c_str(), m_dump_format, m_config_audio.is_live, m_timeout, m_cookie.c_str(), m_user_agent.c_str()))
+  if(!m_omx_reader.Open(m_filename.c_str(), m_dump_format, m_config_audio.is_live, m_timeout, m_cookie.c_str(), m_user_agent.c_str(), m_lavfdopts.c_str()))
     goto do_exit;
 
   if (m_dump_format_exit)


### PR DESCRIPTION
omxplayer on Raspberry Pi is slow to open low-throughput streams. I had this issue when playing mpeg2ts clear QAM streams directly via `/dev/dvb/adapter0/dvr0`, where sometimes it would take around 20 seconds to start playing. It doesn't have to take that long. I traced the cause down to the default `probesize` value of 5000000 in `ffmpeg/libavformat/options_table.h`. By reducing the value to 250000, libavformat is still able to probe the format, but it only takes about 1 second to load. Rather than introduce an omxplayer option to set `probesize` specifically, this patch allows passing a multi-option string to `av_set_options_string`, which should allow setting any number of options defined in `options_table.h`. I chose the name 'lavfdopts` for consistency with `mplayer`.