### PR TITLE
omxplayer: Use complete library path under ffmpeg_compiled for local testing.

### DIFF
--- a/omxplayer
+++ b/omxplayer
@@ -8,7 +8,7 @@ OMXPLAYER_BIN="$OMXPLAYER_DIR/omxplayer.bin"
 OMXPLAYER_LIBS="/opt/vc/lib"
 
 if [ -e "$OMXPLAYER_DIR/ffmpeg_compiled" ]; then
-    OMXPLAYER_LIBS="$OMXPLAYER_LIBS:$OMXPLAYER_DIR/ffmpeg_compiled"
+    OMXPLAYER_LIBS="$OMXPLAYER_LIBS:$OMXPLAYER_DIR/ffmpeg_compiled/usr/local/lib"
 else
     OMXPLAYER_LIBS="$OMXPLAYER_LIBS:/usr/lib/omxplayer"
 fi


### PR DESCRIPTION
The omxplayer wrapper script tests for the existence of $OMXPLAYER_DIR/ffmpeg_compiled, and adds it to OMXPLAYER_LIBS if found, which is apparently for local testing. But the actual .so files are in $OMXPLAYER_DIR/ffmpeg_compiled/usr/local/lib.