### PR TITLE
Makefile: do not preserve ownership when installing libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,5 +88,5 @@ dist: omxplayer.bin omxplayer.1
 	cp COPYING $(DIST)/usr/share/doc/omxplayer
 	cp README.md $(DIST)/usr/share/doc/omxplayer/README
 	cp omxplayer.1 $(DIST)/usr/share/man/man1
-	cp -a ffmpeg_compiled/usr/local/lib/*.so* $(DIST)/usr/lib/omxplayer/
+	cp -P ffmpeg_compiled/usr/local/lib/*.so* $(DIST)/usr/lib/omxplayer/
 	cd $(DIST); tar -czf ../$(DIST).tgz *


### PR DESCRIPTION
Fixes inconsistent ownership when installing files. The owner should be
the user installing the files rather than the original owner.