### PR TITLE
Allow opening "tcp://" and "unix://" URLs.

### DIFF
--- a/OMXReader.cpp
+++ b/OMXReader.cpp
@@ -197,6 +197,7 @@ bool OMXReader::Open(std::string filename, bool dump_format, bool live /* =false
       m_filename.substr(0,7) == "rtmp://" || m_filename.substr(0,6) == "udp://" ||
       m_filename.substr(0,7) == "rtsp://" || m_filename.substr(0,6) == "rtp://" ||
       m_filename.substr(0,6) == "ftp://" || m_filename.substr(0,7) == "sftp://" ||
+      m_filename.substr(0,6) == "tcp://" || m_filename.substr(0,7) == "unix://" ||
       m_filename.substr(0,6) == "smb://")
   {
     // ffmpeg dislikes the useragent from AirPlay urls


### PR DESCRIPTION
This one-liner adds 2 protocols that are supported by ffmpeg,
https://www.ffmpeg.org/ffmpeg-protocols.html#tcp
https://www.ffmpeg.org/ffmpeg-protocols.html#unix

tcp:// works great, and saves me a lot of awful workarounds like creating temporary fifos for omxplayer when playing from a raw tcp stream source.

There is problem with unix://, namely that connect() fails because of the size ffmpeg is passing, but that is a problem to be fixed at the ffmpeg or RPi kernel layer, so I think its Ok to add it here.