### PR TITLE
Bash files bugs fixed

### DIFF
--- a/dbuscontrol.sh
+++ b/dbuscontrol.sh
@@ -2,8 +2,8 @@
 
 #set -x
 
-OMXPLAYER_DBUS_ADDR="/tmp/omxplayerdbus.${USER}"
-OMXPLAYER_DBUS_PID="/tmp/omxplayerdbus.${USER}.pid"
+OMXPLAYER_DBUS_ADDR="/tmp/omxplayerdbus.${USER:-root}"
+OMXPLAYER_DBUS_PID="/tmp/omxplayerdbus.${USER:-root}.pid"
 export DBUS_SESSION_BUS_ADDRESS=`cat $OMXPLAYER_DBUS_ADDR`
 export DBUS_SESSION_BUS_PID=`cat $OMXPLAYER_DBUS_PID`
 


### PR DESCRIPTION
dbuscontrol.sh :
- Use root if no user connected, may appear if the bash is called at the boot process.

omxplayer :
- Fix : Dbus fork not reused across batch calls, a new instance is created at each execution.
- Fix : Error "pgrep does not support -F option"
