### PR TITLE
Fix looping video issues, and white flicker upon end of video

### DIFF
--- a/OMXAudio.cpp
+++ b/OMXAudio.cpp
@@ -1205,7 +1205,10 @@ bool COMXAudio::IsEOS()
   unsigned int latency = GetAudioRenderingLatency();
   CSingleLock lock (m_critSection);
 
-  if (!m_failed_eos && !(m_omx_decoder.IsEOS() && latency == 0))
+  bool hdmi_eos = ( !m_omx_render_hdmi.IsInitialized() ||  m_omx_render_hdmi.IsEOS());
+  bool analog_eos = ( !m_omx_render_analog.IsInitialized() || m_omx_render_analog.IsEOS());
+
+  if (!m_failed_eos && !(hdmi_eos && analog_eos && latency == 0))
     return false;
 
   if (m_submitted_eos)

--- a/OMXPlayerAudio.cpp
+++ b/OMXPlayerAudio.cpp
@@ -281,7 +281,7 @@ void OMXPlayerAudio::Process()
   while(true)
   {
     Lock();
-    if(!(m_bStop || m_bAbort) && m_packets.empty())
+    if(!(m_bStop || m_bAbort) && !omx_pkt && m_packets.empty())
       pthread_cond_wait(&m_packet_cond, &m_lock);
 
     if (m_bStop || m_bAbort)
@@ -290,29 +290,28 @@ void OMXPlayerAudio::Process()
       break;
     }
 
-    if(m_flush && omx_pkt)
+    if(m_flush)
     {
-      OMXReader::FreePacket(omx_pkt);
-      omx_pkt = NULL;
+      if(omx_pkt)
+      {
+        OMXReader::FreePacket(omx_pkt);
+        omx_pkt = NULL;
+      }
       m_flush = false;
     }
-    else if(!omx_pkt && !m_packets.empty())
+
+    if(!omx_pkt && !m_packets.empty())
     {
       omx_pkt = m_packets.front();
-      m_cached_size -= omx_pkt->size;
       m_packets.pop_front();
     }
+
     UnLock();
     
     LockDecoder();
-    if(m_flush && omx_pkt)
+    if(omx_pkt && Decode(omx_pkt))
     {
-      OMXReader::FreePacket(omx_pkt);
-      omx_pkt = NULL;
-      m_flush = false;
-    }
-    else if(omx_pkt && Decode(omx_pkt))
-    {
+      m_cached_size -= omx_pkt->size;
       OMXReader::FreePacket(omx_pkt);
       omx_pkt = NULL;
     }
@@ -359,8 +358,10 @@ bool OMXPlayerAudio::AddPacket(OMXPacket *pkt)
   if((m_cached_size + pkt->size) < m_config.queue_size * 1024 * 1024)
   {
     Lock();
+    LockDecoder();
     m_cached_size += pkt->size;
     m_packets.push_back(pkt);
+    UnLockDecoder();
     UnLock();
     ret = true;
     pthread_cond_broadcast(&m_packet_cond);
@@ -492,36 +493,15 @@ double OMXPlayerAudio::GetCacheTotal()
 
 void OMXPlayerAudio::SubmitEOS()
 {
-  if(m_decoder)
-    m_decoder->SubmitEOS();
+  assert(m_decoder);
+  assert(m_packets.empty());
+  m_decoder->SubmitEOS();
 }
 
 bool OMXPlayerAudio::IsEOS()
 {
-  return m_packets.empty() && (!m_decoder || m_decoder->IsEOS());
+  assert(m_decoder);
+  assert(m_packets.empty());
+  return m_decoder->IsEOS();
 }
-
-void OMXPlayerAudio::WaitCompletion()
-{
-  if(!m_decoder)
-    return;
-
-  unsigned int nTimeOut = m_config.fifo_size * 1000;
-  while(nTimeOut)
-  {
-    if(IsEOS())
-    {
-      CLog::Log(LOGDEBUG, "%s::%s - got eos\n", "OMXPlayerAudio", __func__);
-      break;
-    }
-
-    if(nTimeOut == 0)
-    {
-      CLog::Log(LOGERROR, "%s::%s - wait for eos timed out\n", "OMXPlayerAudio", __func__);
-      break;
-    }
-    OMXClock::OMXSleep(50);
-    nTimeOut -= 50;
-  }
-} 
 

--- a/OMXPlayerAudio.h
+++ b/OMXPlayerAudio.h
@@ -102,7 +102,6 @@ public:
   double GetCurrentPTS() { return m_iCurrentPts; };
   void SubmitEOS();
   bool IsEOS();
-  void WaitCompletion();
   unsigned int GetCached() { return m_cached_size; };
   unsigned int GetMaxCached() { return m_config.queue_size * 1024 * 1024; };
   unsigned int GetLevel() { return m_config.queue_size ? 100.0f * m_cached_size / (m_config.queue_size * 1024.0f * 1024.0f) : 0; };


### PR DESCRIPTION
See several looping short video issues (e.g. #449) and white flicker #250 

The root cause of all evil: the submission of the EOS.

To submit the (audio and/or video) EOS the condition to do so is that its (decoder) cache is empty.
 
The problem is that the variable being used ```m_cached_size``` is decreased (minus ```pkt->size```) directly after a packet is popped from the queue (/cache) whereas it must be after the popped (end) packet is decoded. This causes the EOS packet to be sent (to the ```m_decoder```) BEFORE the end packet: the result is the video/audio stream is EOS-ed BEFORE the end packet is actually shown by the renderer.