### PR TITLE
Raise output frequency of stats output (-s) to ~50 values per second

### DIFF
--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1602,11 +1602,10 @@ int main(int argc, char *argv[])
       if(m_stats)
       {
         static int count;
-        if ((count++ & 7) == 0)
-           printf("M:%8.0f V:%6.2fs %6dk/%6dk A:%6.2f %6.02fs/%6.02fs Cv:%6dk Ca:%6dk                            \r", stamp,
-               video_fifo, (m_player_video.GetDecoderBufferSize()-m_player_video.GetDecoderFreeSpace())>>10, m_player_video.GetDecoderBufferSize()>>10,
-               audio_fifo, m_player_audio.GetDelay(), m_player_audio.GetCacheTotal(),
-               m_player_video.GetCached()>>10, m_player_audio.GetCached()>>10);
+        printf("M:%8.0f V:%6.2fs %6dk/%6dk A:%6.2f %6.02fs/%6.02fs Cv:%6dk Ca:%6dk                            \r", stamp,
+            video_fifo, (m_player_video.GetDecoderBufferSize()-m_player_video.GetDecoderFreeSpace())>>10, m_player_video.GetDecoderBufferSize()>>10,
+            audio_fifo, m_player_audio.GetDelay(), m_player_audio.GetCacheTotal(),
+            m_player_video.GetCached()>>10, m_player_audio.GetCached()>>10);
       }
 
       if(m_tv_show_info)


### PR DESCRIPTION
This was taken care for in 116de6, but somehow it is now around 5 values per second.

This is patch is needed for OMXPlayer-Sync, a solution that builds ontop of omxplayer and facilitates synchronization of multiple OMXPlayer instances over the network in a master/slave fashion.