### PR TITLE
Add libasound2-dev as required package

### DIFF
--- a/prepare-native-raspbian.sh
+++ b/prepare-native-raspbian.sh
@@ -15,7 +15,7 @@ if [ -z `which sudo` ] ; then
 fi
     
 echo "Checking dpkg database for missing packages"
-REQUIRED_PKGS="ca-certificates git-core subversion binutils libva1 libpcre3-dev libidn11-dev libboost1.50-dev libfreetype6-dev libusb-1.0-0-dev libdbus-1-dev libssl-dev libssh-dev libsmbclient-dev gcc-4.7 g++-4.7 sed pkg-config"
+REQUIRED_PKGS="ca-certificates git-core subversion binutils libasound2-dev libva1 libpcre3-dev libidn11-dev libboost1.50-dev libfreetype6-dev libusb-1.0-0-dev libdbus-1-dev libssl-dev libssh-dev libsmbclient-dev gcc-4.7 g++-4.7 sed pkg-config"
 MISSING_PKGS=""
 for pkg in $REQUIRED_PKGS
 do


### PR DESCRIPTION
The recently added ALSA support requires the libasound2-dev package to
be able to compile on a Jessy based Raspbian.

This fixes the following compile error:

~~~~~
linux/OMXAlsa.cpp:21:28: fatal error: alsa/asoundlib.h: No such file or directory compilation terminated.
Makefile:46: recipe for target 'linux/OMXAlsa.o' failed
make: *** [linux/OMXAlsa.o] Error 1
~~~~~

Fixes: c84083d15cbd ("Initial alsa support")