### PR TITLE
bugfix: "dbuscontrol.sh getsource" to return exit code 1 on error

### DIFF
--- a/dbuscontrol.sh
+++ b/dbuscontrol.sh
@@ -98,6 +98,7 @@ showsubtitles)
 	;;
 getsource)
 	source=$(dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.GetSource)
+	[ $? -ne 0 ] && exit 1
 	echo "$source" | sed 's/^ *//'
 	;;
 *)


### PR DESCRIPTION
This behavior is already correctly implemented for the other "dbuscontrol.sh" commands, when "dbus-send" fails. I'm re-using the existing error handling code.