### PR TITLE
Added function start-paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Usage: omxplayer [OPTIONS] [FILE]
         --user-agent 'ua'       Send specified User-Agent as part of HTTP requests
         --lavfdopts 'opts'      Options passed to libavformat, e.g. 'probesize:250000,...'
         --avdict 'opts'         Options passed to demuxer, e.g., 'rtsp_transport:tcp,...'
+        --start-paused          Immediately pause the video after loading, will wait for dbus or key command to play
 
 For example:
 

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -114,6 +114,7 @@ bool              m_has_audio           = false;
 bool              m_has_subtitle        = false;
 bool              m_gen_log             = false;
 bool              m_loop                = false;
+bool              m_start_paused        = false;
 
 enum{ERROR=-1,SUCCESS,ONEBYTE};
 
@@ -569,6 +570,7 @@ int main(int argc, char *argv[])
   const int http_user_agent_opt = 0x301;
   const int lavfdopts_opt   = 0x400;
   const int avdict_opt      = 0x401;
+  const int start_paused    = 0x214;
 
   struct option longopts[] = {
     { "info",         no_argument,        NULL,          'i' },
@@ -618,6 +620,7 @@ int main(int argc, char *argv[])
     { "key-config",   required_argument,  NULL,          key_config_opt },
     { "no-osd",       no_argument,        NULL,          no_osd_opt },
     { "no-keys",      no_argument,        NULL,          no_keys_opt },
+    { "start-paused", no_argument,        NULL,          start_paused },
     { "orientation",  required_argument,  NULL,          orientation_opt },
     { "fps",          required_argument,  NULL,          fps_opt },
     { "live",         no_argument,        NULL,          live_opt },
@@ -764,6 +767,9 @@ int main(int argc, char *argv[])
         break;
       case no_keys_opt:
         m_no_keys = true;
+        break;
+      case start_paused:
+        m_start_paused = true;
         break;
       case font_opt:
         m_font_path = optarg;
@@ -1435,6 +1441,7 @@ int main(int argc, char *argv[])
           break;
       case KeyConfig::ACTION_PLAY:
         m_Pause=false;
+        //m_start_paused=false;
         if(m_has_subtitle)
         {
           m_player_subtitles.Resume();
@@ -1442,6 +1449,7 @@ int main(int argc, char *argv[])
         break;
       case KeyConfig::ACTION_PAUSE:
         m_Pause=true;
+        //m_start_paused=false;
         if(m_has_subtitle)
         {
           m_player_subtitles.Pause();
@@ -1449,6 +1457,7 @@ int main(int argc, char *argv[])
         break;
       case KeyConfig::ACTION_PLAYPAUSE:
         m_Pause = !m_Pause;
+        //m_start_paused = false;
         if (m_av_clock->OMXPlaySpeed() != DVD_PLAYSPEED_NORMAL && m_av_clock->OMXPlaySpeed() != DVD_PLAYSPEED_PAUSE)
         {
           printf("resume\n");
@@ -1722,8 +1731,19 @@ int main(int argc, char *argv[])
       {
         if (m_av_clock->OMXIsPaused())
         {
-          CLog::Log(LOGDEBUG, "Resume %.2f,%.2f (%d,%d,%d,%d) EOF:%d PKT:%p\n", audio_fifo, video_fifo, audio_fifo_low, video_fifo_low, audio_fifo_high, video_fifo_high, m_omx_reader.IsEof(), m_omx_pkt);
-          m_av_clock->OMXResume();
+          if (!m_start_paused)
+          {
+            CLog::Log(LOGDEBUG, "Resume %.2f,%.2f (%d,%d,%d,%d) EOF:%d PKT:%p\n", audio_fifo, video_fifo, audio_fifo_low, video_fifo_low, audio_fifo_high, video_fifo_high, m_omx_reader.IsEof(), m_omx_pkt);
+            m_av_clock->OMXResume();
+          }
+          else
+          {
+            CLog::Log(LOGDEBUG, "start-paused(%d)\n", m_start_paused);
+            m_av_clock->OMXResume();
+            m_Pause=true;
+            m_start_paused=false;
+            m_av_clock->OMXPause();
+          }
         }
       }
       else if (m_Pause || audio_fifo_low || video_fifo_low)


### PR DESCRIPTION
This function allows a user to start omxplayer in a paused state instead
of immediately starting playback of the video.  The user can then use
standard keyboard or dbus commands to begin playback manually.

To use this function add the command-line parameter: --start-paused to
the omxplayer command.

Example:

omxplayer -p -o hdmi --start-paused test.mkv

This will start the omxplayer, load the buffer to begin playback and
then pause.  To resume playback, press the key on the keyboard for
resume (by default this is the p or space keys), or send a dbus command.