### PR TITLE
DBus Get Rate returns not the current rate after a DBUS Set Rate.

### DIFF
--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -562,7 +562,8 @@ OMXControlResult OMXControl::handle_event(DBusMessage *m)
         if(iSpeed > MAX_RATE)
           iSpeed=MAX_RATE;
         dbus_respond_double(m, iSpeed/1000.);//Reply before applying to be faster
-        clock->OMXSetSpeed(iSpeed, false, true);
+        clock->OMXSetSpeed(iSpeed);
+        clock->OMXSetSpeed(iSpeed, true, true);
         return KeyConfig::ACTION_PLAY;
       }
       //Wrong property

--- a/dbuscontrol.sh
+++ b/dbuscontrol.sh
@@ -101,8 +101,16 @@ getsource)
 	[ $? -ne 0 ] && exit 1
 	echo "$source" | sed 's/^ *//'
 	;;
+rate)
+	if [ "$#" -eq 1 ]; then
+		rate=`dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:"org.mpris.MediaPlayer2.Player" string:"Rate"`
+	else
+		rate=`dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Set string:"org.mpris.MediaPlayer2.Player" string:"Rate" ${2:+double:}$2`
+	fi
+	echo $rate
+	;;
 *)
-	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|togglesubtitles|hidesubtitles|showsubtitles|setvideopos [x1 y1 x2 y2]|setvideocroppos [x1 y1 x2 y2]|setaspectmode [letterbox,fill,stretch,default]|setalpha [alpha (0..255)]|getsource" >&2
+	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|togglesubtitles|hidesubtitles|showsubtitles|setvideopos [x1 y1 x2 y2]|setvideocroppos [x1 y1 x2 y2]|setaspectmode [letterbox,fill,stretch,default]|setalpha [alpha (0..255)]|getsource|rate" >&2
 	exit 1
 	;;
 esac


### PR DESCRIPTION
As found by Will Price in his python-omxplayer-wrapper [`set_rate` integration test #109](https://github.com/willprice/python-omxplayer-wrapper/issues/109)

When setting the Rate through DBus Set Property, the Rate returned by the DBus Get Property doesn't reflect the Rate set.

OMXControl calls the clock OMXSetSpeed with pause_resume argument set to true. This value however doesn't set the (clock internal) variable m_omx_speed. The value of this variable is returned (through OMXPlaySpeed) by the Get Property.

The solution uses the same construction as omxplayer.cpp::SetSpeed to set the clock speed: first call to update the m_omx_speed and a second call to actually set the speed.

Expanded dbuscontrol.sh for Rate Get and Set Property testing:
- `dbuscontrol.sh rate` gets the current rate value, and
- `dbuscontrol.sh rate VALUE` sets the current rate to VALUE. VALUE is a double datatype value e.g. 1.125.
