### PR TITLE
Added DisplayText DBUS support

### DIFF
--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -219,6 +219,31 @@ OMXControlResult OMXControl::handle_event(DBusMessage *m)
     //Does nothing
     return KeyConfig::ACTION_BLANK;
   }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_ROOT, "DisplayText"))
+  {
+    DBusError error;
+    dbus_error_init(&error);
+    
+    const char *msg;
+    int64_t duration;
+    
+    dbus_message_get_args(m, &error, DBUS_TYPE_STRING, &msg, DBUS_TYPE_INT64, &duration, DBUS_TYPE_INVALID);
+    
+    // Make sure values are sent for setting DisplayText
+    if (dbus_error_is_set(&error))
+    {
+      CLog::Log(LOGWARNING, "DisplayText D-Bus Error: %s", error.message );
+      dbus_error_free(&error);
+      dbus_respond_ok(m);
+      return KeyConfig::ACTION_BLANK;
+    }
+    else
+    {
+      subtitles->DisplayText(msg, duration);
+      dbus_respond_ok(m);
+      return KeyConfig::ACTION_BLANK;
+    }
+  }
   //Properties Get method:
   //TODO: implement GetAll
   else if (dbus_message_is_method_call(m, DBUS_INTERFACE_PROPERTIES, "Get"))

--- a/OMXPlayerSubtitles.cpp
+++ b/OMXPlayerSubtitles.cpp
@@ -61,6 +61,7 @@ bool OMXPlayerSubtitles::Open(size_t stream_count,
                               float font_size,
                               bool centered,
                               bool ghost_box,
+                              bool osd,
                               unsigned int lines,
                               int display, int layer,
                               OMXClock* clock) BOOST_NOEXCEPT
@@ -81,6 +82,7 @@ bool OMXPlayerSubtitles::Open(size_t stream_count,
   m_font_size = font_size;
   m_centered = centered;
   m_ghost_box = ghost_box;
+  m_osd = osd;
   m_lines = lines;
   m_av_clock = clock;
   m_display = display;
@@ -490,11 +492,12 @@ bool OMXPlayerSubtitles::AddPacket(OMXPacket *pkt, size_t stream_index) BOOST_NO
 
 void OMXPlayerSubtitles::DisplayText(const std::string& text, int duration) BOOST_NOEXCEPT
 {
-  assert(m_open);
-
-  vector<string> text_lines;
-  split(text_lines, text, is_any_of("\n"));
-  SendToRenderer(Message::DisplayText{std::move(text_lines), duration});
+  if(m_osd){
+    assert(m_open);
+    vector<string> text_lines;
+    split(text_lines, text, is_any_of("\n"));
+    SendToRenderer(Message::DisplayText{std::move(text_lines), duration});
+  }
 }
 
 void OMXPlayerSubtitles::SetSubtitleRect(int x1, int y1, int x2, int y2) BOOST_NOEXCEPT

--- a/OMXPlayerSubtitles.h
+++ b/OMXPlayerSubtitles.h
@@ -46,6 +46,7 @@ public:
             float font_size,
             bool centered,
             bool ghost_box,
+            bool osd,
             unsigned int lines,
             int display, int layer,
             OMXClock* clock) BOOST_NOEXCEPT;
@@ -170,6 +171,7 @@ private:
   float                                         m_font_size;
   bool                                          m_centered;
   bool                                          m_ghost_box;
+  bool                                          m_osd;
   unsigned int                                  m_lines;
   OMXClock*                                     m_av_clock;
   int                                           m_display;

--- a/README.md
+++ b/README.md
@@ -226,6 +226,17 @@ No effect.
    Params       |   Type
 :-------------: | -------
  Return         | `null`
+ 
+##### DisplayText
+
+Display a message for the specified amount of time. If omxplayer is run with
+--no-osd, no message is displayed
+
+   Params       |   Type    | Description
+:-------------: | ----------| ------------------
+ 1              | `string`  | Message to display
+ 2              | `int64`   | Microseconds to display
+ Return         | `null`    | 
 
 #### Properties
 

--- a/dbuscontrol.sh
+++ b/dbuscontrol.sh
@@ -10,6 +10,10 @@ export DBUS_SESSION_BUS_PID=`cat $OMXPLAYER_DBUS_PID`
 [ -z "$DBUS_SESSION_BUS_ADDRESS" ] && { echo "Must have DBUS_SESSION_BUS_ADDRESS" >&2; exit 1; }
 
 case $1 in
+displaytext)
+    dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.DisplayText string:"$2" int64:$3 >/dev/null
+    ;;
+
 status)
 	duration=`dbus-send --print-reply=literal --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:"org.mpris.MediaPlayer2.Player" string:"Duration"`
 	[ $? -ne 0 ] && exit 1

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -67,7 +67,7 @@ extern "C" {
 // when we repeatedly seek, rather than play continuously
 #define TRICKPLAY(speed) (speed < 0 || speed > 4 * DVD_PLAYSPEED_NORMAL)
 
-#define DISPLAY_TEXT(text, ms) if(m_osd) m_player_subtitles.DisplayText(text, ms)
+#define DISPLAY_TEXT(text, ms) m_player_subtitles.DisplayText(text, ms)
 
 #define DISPLAY_TEXT_SHORT(text) DISPLAY_TEXT(text, 1000)
 #define DISPLAY_TEXT_LONG(text) DISPLAY_TEXT(text, 2000)
@@ -1116,6 +1116,7 @@ int main(int argc, char *argv[])
                                 m_font_size,
                                 m_centered,
                                 m_ghost_box,
+                                m_osd,
                                 m_subtitle_lines,
                                 m_config_video.display, m_config_video.layer + 1,
                                 m_av_clock))


### PR DESCRIPTION
I added the DisplayText to the Root Interface, because I felt that the Player Interface had more to do about controlling the playback.

To avoid passing the m_osd variable directly to OMXControl, which felt cumbersome, I decided to pass it to OMXPlayerSubtitles. This way OMXPlayerSubtitles.DisplayText() checks whether it's true, and prints the text if that's the case.

I also updated the README and dbuscontrol.sh accordingly.


#587