### PR TITLE
Added dbus OpenUri command to change the video source URI. 

### DIFF
--- a/KeyConfig.h
+++ b/KeyConfig.h
@@ -43,6 +43,7 @@ class KeyConfig
         ACTION_CROP_VIDEO = 34,
         ACTION_PAUSE = 35,
         ACTION_PLAY = 36,
+	ACTION_CHANGE_FILE = 37,
     };
 
     #define KEY_LEFT 0x5b44

--- a/OMXControl.cpp
+++ b/OMXControl.cpp
@@ -1103,6 +1103,27 @@ OMXControlResult OMXControl::handle_event(DBusMessage *m)
     dbus_respond_ok(m);
     return KeyConfig::ACTION_HIDE_SUBTITLES;
   }
+  else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "OpenUri"))
+  {
+    DBusError error;
+    dbus_error_init(&error);
+
+    const char *file;
+    dbus_message_get_args(m, &error, DBUS_TYPE_STRING, &file, DBUS_TYPE_INVALID);
+
+    if (dbus_error_is_set(&error))
+    {
+      CLog::Log(LOGWARNING, "Change file D-Bus Error: %s", error.message );
+      dbus_error_free(&error);
+      dbus_respond_ok(m);
+      return KeyConfig::ACTION_BLANK;
+    }
+    else
+    {
+      dbus_respond_string(m, file);
+      return OMXControlResult(KeyConfig::ACTION_CHANGE_FILE, file);
+    }
+  }
   else if (dbus_message_is_method_call(m, OMXPLAYER_DBUS_INTERFACE_PLAYER, "Action"))
   {
     DBusError error;

--- a/README.md
+++ b/README.md
@@ -582,6 +582,14 @@ Millibels can be converted to/from acceptable values using the following:
 
 [MPRIS_volume]: http://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Simple-Type:Volume
 
+##### OpenUri (w)
+
+Restart and open another URI for playing.
+
+   Params       |   Type    | Description
+:-------------: | --------- | --------------------------------
+1               | `string`  | URI to play
+
 ##### Position (ro)
 
 Returns the current position of the playing media.

--- a/dbuscontrol.sh
+++ b/dbuscontrol.sh
@@ -30,6 +30,10 @@ status)
 	echo "Paused: $paused"
 	;;
 
+openuri)
+	dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.OpenUri string:"$2" >/dev/null
+	;;
+
 volume)
 	volume=`dbus-send --print-reply=double --session --reply-timeout=500 --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Set string:"org.mpris.MediaPlayer2.Player" string:"Volume" ${2:+double:}$2`
 	[ $? -ne 0 ] && exit 1
@@ -102,7 +106,7 @@ getsource)
 	echo "$source" | sed 's/^ *//'
 	;;
 *)
-	echo "usage: $0 status|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|togglesubtitles|hidesubtitles|showsubtitles|setvideopos [x1 y1 x2 y2]|setvideocroppos [x1 y1 x2 y2]|setaspectmode [letterbox,fill,stretch,default]|setalpha [alpha (0..255)]|getsource" >&2
+	echo "usage: $0 status|openuri|pause|stop|seek|volumeup|volumedown|setposition [position in microseconds]|hidevideo|unhidevideo|togglesubtitles|hidesubtitles|showsubtitles|setvideopos [x1 y1 x2 y2]|setvideocroppos [x1 y1 x2 y2]|setaspectmode [letterbox,fill,stretch,default]|setalpha [alpha (0..255)]|getsource" >&2
 	exit 1
 	;;
 esac

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1024,6 +1024,8 @@ int main(int argc, char *argv[])
     m_keyboard->setDbusName(m_dbus_name);
   }
 
+  change_file:
+
   if(!m_omx_reader.Open(m_filename.c_str(), m_dump_format, m_config_audio.is_live, m_timeout, m_cookie.c_str(), m_user_agent.c_str(), m_lavfdopts.c_str(), m_avdict.c_str()))
     goto do_exit;
 
@@ -1200,6 +1202,15 @@ int main(int argc, char *argv[])
 
     switch(result.getKey())
     {
+     case KeyConfig::ACTION_CHANGE_FILE:
+        FlushStreams(DVD_NOPTS_VALUE);
+        m_omx_reader.Close();
+        m_player_subtitles.Close();
+        m_player_video.Close();
+        m_player_audio.Close();
+        m_filename = result.getWinArg();
+        goto change_file;
+        break;
       case KeyConfig::ACTION_SHOW_INFO:
         m_tv_show_info = !m_tv_show_info;
         vc_tv_show_info(m_tv_show_info);


### PR DESCRIPTION
As proposed on Github by popcornmix/omxplayer issue #528 by @medismail . Changed command name to 'OpenUri' as proposed by MPRIS2 specification. Added command to `dbuscontro.sh` and readme.

This is something like a player restart, the terminal need to be blanked otherwise it may reappear while opening the new file. On the other hand, it should handle resolution changes etc. gracefully.

Feel free for extensive testing.