### PR TITLE
Options for start and end paused

### DIFF
--- a/OMXVideo.cpp
+++ b/OMXVideo.cpp
@@ -723,8 +723,8 @@ int COMXVideo::Decode(uint8_t *pData, int iSize, double dts, double pts)
   if( m_drop_state || !m_is_open )
     return true;
 
-    unsigned int demuxer_bytes = (unsigned int)iSize;
-    uint8_t *demuxer_content = pData;
+  unsigned int demuxer_bytes = (unsigned int)iSize;
+  uint8_t *demuxer_content = pData;
 
   if (demuxer_content && demuxer_bytes > 0)
   {

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Usage: omxplayer [OPTIONS] [FILE]
         --lavfdopts 'opts'      Options passed to libavformat, e.g. 'probesize:250000,...'
         --avdict 'opts'         Options passed to demuxer, e.g., 'rtsp_transport:tcp,...'
         --start-paused          Immediately pause the video after loading, will wait for dbus or key command to play
+        --end-paused            Pause the video on the last frame indefinitely
 
 For example:
 

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -115,6 +115,7 @@ bool              m_has_subtitle        = false;
 bool              m_gen_log             = false;
 bool              m_loop                = false;
 bool              m_start_paused        = false;
+bool              m_end_paused          = false;
 
 enum{ERROR=-1,SUCCESS,ONEBYTE};
 
@@ -571,6 +572,7 @@ int main(int argc, char *argv[])
   const int lavfdopts_opt   = 0x400;
   const int avdict_opt      = 0x401;
   const int start_paused    = 0x214;
+  const int end_paused      = 0x215;
 
   struct option longopts[] = {
     { "info",         no_argument,        NULL,          'i' },
@@ -621,6 +623,7 @@ int main(int argc, char *argv[])
     { "no-osd",       no_argument,        NULL,          no_osd_opt },
     { "no-keys",      no_argument,        NULL,          no_keys_opt },
     { "start-paused", no_argument,        NULL,          start_paused },
+    { "end-paused",   no_argument,        NULL,          end_paused },
     { "orientation",  required_argument,  NULL,          orientation_opt },
     { "fps",          required_argument,  NULL,          fps_opt },
     { "live",         no_argument,        NULL,          live_opt },
@@ -770,6 +773,9 @@ int main(int argc, char *argv[])
         break;
       case start_paused:
         m_start_paused = true;
+        break;
+      case end_paused:
+        m_end_paused = true;
         break;
       case font_opt:
         m_font_path = optarg;
@@ -1811,7 +1817,8 @@ int main(int argc, char *argv[])
         continue;
       }
 
-      break;
+      if (!m_end_paused)
+        break;
     }
 
     if(m_has_video && m_omx_pkt && m_omx_reader.IsActive(OMXSTREAM_VIDEO, m_omx_pkt->stream_index))


### PR DESCRIPTION
Adds options to pause at first frame (written some time ago by bholmes451) and the last frame. 

Pausing on first frame allow a player to start fast  when needed on files that require some preloading, and start mulitple players running synchronously. 

Pausing at the the last frame prevents the console to reappear and the audience to leave the room unnerded :-). It also allow for more complex schemes where two layered omxplayers are used for seamless playback of multiple files.