### PR TITLE
fix GPL mailing address

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
This change updates the gpl mailing address to the current one [1], which fixes the following error from rpmlint:
```
omxplayer.armv7hl: E: incorrect-fsf-address /usr/share/licenses/omxplayer/COPYING
```
[1] https://www.gnu.org/licenses/gpl-2.0.html