### PR TITLE
use "type -p" instead of "which"

### DIFF
--- a/omxplayer
+++ b/omxplayer
@@ -16,9 +16,9 @@ fi
 refresh_regex='(|.* )(-r|--refresh)( .*|$)'
 audio_regex='.*\.(mp3|wav|wma|cda|ogg|ogm|aac|ac3|flac)( .*|$)'
 
-fbset_bin=`which fbset`
-xset_bin=`which xset`
-xrefresh_bin=`which xrefresh`
+fbset_bin=`type -p fbset`
+xset_bin=`type -p xset`
+xrefresh_bin=`type -p xrefresh`
 
 if [ -z $NOREFRESH ] || [ "$NOREFRESH" == "0" ]; then
     if [[ $@ =~ $refresh_regex ]] && [[ ! $@ =~ $audio_regex ]]; then


### PR DESCRIPTION
On Raspberry Pi's without a desktop, the following non-fatal error messages appear when starting omxplayer:

```
/usr/bin/omxplayer: line 25: which: command not found
/usr/bin/omxplayer: line 26: which: command not found
/usr/bin/omxplayer: line 27: which: command not found
```

These errors are a result of the `which` command failing to find the fbset, xset, and xrefresh binaries, which are only present when running xserver.

One way to avoid seeing the error message is to use `type -p` rather than `which`. Alternatively one could just pipe stderror to /dev/null. I chose the former, but either way works fine.