### PR TITLE
Added option --force-fps

### DIFF
--- a/OMXVideo.cpp
+++ b/OMXVideo.cpp
@@ -719,6 +719,7 @@ unsigned int COMXVideo::GetSize()
   return m_omx_decoder.GetInputBufferSize();
 }
 
+long fake_pts=0;
 int COMXVideo::Decode(uint8_t *pData, int iSize, double dts, double pts)
 {
   CSingleLock lock (m_critSection);
@@ -740,6 +741,13 @@ int COMXVideo::Decode(uint8_t *pData, int iSize, double dts, double pts)
       CLog::Log(LOGDEBUG, "OMXVideo::Decode VDec : setStartTime %f\n", (pts == DVD_NOPTS_VALUE ? 0.0 : pts) / DVD_TIME_BASE);
       m_setStartTime = false;
     }
+
+    if(m_config.force_fps>0) {
+	pts=fake_pts;
+        fake_pts += (1000000L / m_config.force_fps);
+        CLog::Log(LOGDEBUG, "OMXVideo::Decode VDec : force-pts fake_pts %ld\n", fake_pts);
+    }
+
     if (pts == DVD_NOPTS_VALUE && dts == DVD_NOPTS_VALUE)
       nFlags |= OMX_BUFFERFLAG_TIME_UNKNOWN;
     else if (pts == DVD_NOPTS_VALUE)

--- a/OMXVideo.h
+++ b/OMXVideo.h
@@ -63,6 +63,7 @@ public:
   int layer;
   float queue_size;
   float fifo_size;
+  int force_fps;
 
   OMXVideoConfig()
   {
@@ -81,6 +82,7 @@ public:
     layer = 0;
     queue_size = 10.0f;
     fifo_size = (float)80*1024*60 / (1024*1024);
+    force_fps=0;
   }
 };
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Usage: omxplayer [OPTIONS] [FILE]
         --timeout     n         Timeout for stalled file/network operations (default 10s)
         --orientation n         Set orientation of video (0, 90, 180 or 270)
         --fps n                 Set fps of video where timestamps are not present
+        --force-fps n           Force the given fps, even if timestamps are present
         --live                  Set for live tv or vod type stream
         --layout                Set output speaker layout (e.g. 5.1)
         --dbus_name name        default: org.mpris.MediaPlayer2.omxplayer

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -569,6 +569,7 @@ int main(int argc, char *argv[])
   const int http_user_agent_opt = 0x301;
   const int lavfdopts_opt   = 0x400;
   const int avdict_opt      = 0x401;
+  const int force_fps_opt   = 0x402;
 
   struct option longopts[] = {
     { "info",         no_argument,        NULL,          'i' },
@@ -631,6 +632,7 @@ int main(int argc, char *argv[])
     { "user-agent",   required_argument,  NULL,          http_user_agent_opt },
     { "lavfdopts",    required_argument,  NULL,          lavfdopts_opt },
     { "avdict",       required_argument,  NULL,          avdict_opt },
+    { "force-fps",    required_argument,  NULL,          force_fps_opt },
     { 0, 0, 0, 0 }
   };
 
@@ -892,6 +894,9 @@ int main(int argc, char *argv[])
         break;
       case display_opt:
         m_config_video.display = atoi(optarg);
+        break;
+      case force_fps_opt:
+        m_config_video.force_fps = atoi(optarg);
         break;
       case http_cookie_opt:
         m_cookie = optarg;


### PR DESCRIPTION
A new option --force-fps creates synthetic timestamps to force playback at the given rate, overriding original media timestamps.