### PR TITLE
Stop showing automatically found external subtitles by default

### DIFF
--- a/OMXPlayerSubtitles.cpp
+++ b/OMXPlayerSubtitles.cpp
@@ -490,8 +490,6 @@ bool OMXPlayerSubtitles::AddPacket(OMXPacket *pkt, size_t stream_index) BOOST_NO
 
 void OMXPlayerSubtitles::DisplayText(const std::string& text, int duration) BOOST_NOEXCEPT
 {
-  assert(m_open);
-
   vector<string> text_lines;
   split(text_lines, text, is_any_of("\n"));
   SendToRenderer(Message::DisplayText{std::move(text_lines), duration});

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Usage: omxplayer [OPTIONS] [FILE]
         --no-osd                Do not display status information on screen
         --no-keys               Disable keyboard input (prevents hangs for certain TTYs)
         --subtitles path        External subtitles in UTF-8 srt format
+        --hide-subtitles        Hide subtitles (shown by default if found)
         --font path             Default: /usr/share/fonts/truetype/freefont/FreeSans.ttf
         --italic-font path      Default: /usr/share/fonts/truetype/freefont/FreeSansOblique.ttf
         --font-size size        Font size in 1/1000 screen height (default: 55)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Usage: omxplayer [OPTIONS] [FILE]
         --no-osd                Do not display status information on screen
         --no-keys               Disable keyboard input (prevents hangs for certain TTYs)
         --subtitles path        External subtitles in UTF-8 srt format
-        --hide-subtitles        Hide subtitles (shown by default if found)
         --font path             Default: /usr/share/fonts/truetype/freefont/FreeSans.ttf
         --italic-font path      Default: /usr/share/fonts/truetype/freefont/FreeSansOblique.ttf
         --font-size size        Font size in 1/1000 screen height (default: 55)

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -789,6 +789,7 @@ int main(int argc, char *argv[])
       case subtitles_opt:
         m_external_subtitles_path = optarg;
         m_has_external_subtitles = true;
+        m_subtitle_index = 0;
         break;
       case lines_opt:
         m_subtitle_lines = std::max(atoi(optarg), 1);

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -968,6 +968,8 @@ int main(int argc, char *argv[])
     return EXIT_FAILURE;
   }
 
+  DISPLAY_TEXT_LONG("Loading...");
+
   if(!m_has_external_subtitles && !filename_is_URL)
   {
     auto subtitles_path = m_filename.substr(0, m_filename.find_last_of(".")) +
@@ -1451,20 +1453,14 @@ int main(int argc, char *argv[])
           break;
       case KeyConfig::ACTION_PLAY:
         m_Pause=false;
-        if(m_has_subtitle)
-        {
-          m_player_subtitles.Resume();
-        }
-        break;
+        goto play_pause;
       case KeyConfig::ACTION_PAUSE:
         m_Pause=true;
-        if(m_has_subtitle)
-        {
-          m_player_subtitles.Pause();
-        }
-        break;
+        goto play_pause;
       case KeyConfig::ACTION_PLAYPAUSE:
         m_Pause = !m_Pause;
+
+        play_pause:
         if (m_av_clock->OMXPlaySpeed() != DVD_PLAYSPEED_NORMAL && m_av_clock->OMXPlaySpeed() != DVD_PLAYSPEED_PAUSE)
         {
           printf("resume\n");
@@ -1833,11 +1829,8 @@ do_exit:
   if (m_stats)
     printf("\n");
 
-  if (m_stop)
-  {
     unsigned t = (unsigned)(m_av_clock->OMXMediaTime()*1e-6);
     printf("Stopped at: %02d:%02d:%02d\n", (t/3600), (t/60)%60, t%60);
-  }
 
   if (m_NativeDeinterlace)
   {

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1829,8 +1829,8 @@ do_exit:
   if (m_stats)
     printf("\n");
 
-    unsigned t = (unsigned)(m_av_clock->OMXMediaTime()*1e-6);
-    printf("Stopped at: %02d:%02d:%02d\n", (t/3600), (t/60)%60, t%60);
+  unsigned t = (unsigned)(m_av_clock->OMXMediaTime()*1e-6);
+  printf("Stopped at: %02d:%02d:%02d\n", (t/3600), (t/60)%60, t%60);
 
   if (m_NativeDeinterlace)
   {

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -80,7 +80,6 @@ long              m_Amplification       = 0;
 bool              m_NativeDeinterlace   = false;
 bool              m_HWDecode            = false;
 bool              m_osd                 = true;
-bool              m_show_subtitles      = true;
 bool              m_no_keys             = false;
 std::string       m_external_subtitles_path;
 bool              m_has_external_subtitles = false;
@@ -551,7 +550,6 @@ int main(int argc, char *argv[])
   const int key_config_opt  = 0x10d;
   const int amp_opt         = 0x10e;
   const int no_osd_opt      = 0x202;
-  const int hide_subtitles_opt= 0x214;
   const int orientation_opt = 0x204;
   const int fps_opt         = 0x208;
   const int live_opt        = 0x205;
@@ -619,7 +617,6 @@ int main(int argc, char *argv[])
     { "no-boost-on-downmix", no_argument, NULL,          no_boost_on_downmix_opt },
     { "key-config",   required_argument,  NULL,          key_config_opt },
     { "no-osd",       no_argument,        NULL,          no_osd_opt },
-    { "hide-subtitles", no_argument,      NULL,          hide_subtitles_opt },
     { "no-keys",      no_argument,        NULL,          no_keys_opt },
     { "orientation",  required_argument,  NULL,          orientation_opt },
     { "fps",          required_argument,  NULL,          fps_opt },
@@ -764,9 +761,6 @@ int main(int argc, char *argv[])
         break;
       case no_osd_opt:
         m_osd = false;
-        break;
-     case hide_subtitles_opt:
-        m_show_subtitles = false;
         break;
       case no_keys_opt:
         m_no_keys = true;
@@ -1144,7 +1138,7 @@ int main(int argc, char *argv[])
       m_player_subtitles.SetUseExternalSubtitles(false);
     }
 
-   if(!m_show_subtitles || (m_subtitle_index == -1 && !m_has_external_subtitles))
+    if(m_subtitle_index == -1 && !m_has_external_subtitles)
       m_player_subtitles.SetVisible(false);
   }
 
@@ -1211,7 +1205,6 @@ int main(int argc, char *argv[])
      case KeyConfig::ACTION_CHANGE_FILE:
         FlushStreams(DVD_NOPTS_VALUE);
         m_omx_reader.Close();
-        m_show_subtitles = m_player_subtitles.GetVisible(); // current pref
         m_player_subtitles.Close();
         m_player_video.Close();
         m_player_audio.Close();

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1036,6 +1036,32 @@ int main(int argc, char *argv[])
   if (m_dump_format_exit)
     goto do_exit;
 
+  // auto select an audio stream
+  // Avoid defaulting to narrative description
+  if(m_audio_index_use == 0)
+  {
+    int audiostreamcount = m_omx_reader.AudioStreamCount();
+
+    if(audiostreamcount > 1)
+    {
+      for(int i=0; i < audiostreamcount; i++)
+      {
+        std::string lang = m_omx_reader.GetStreamLanguage(OMXSTREAM_AUDIO, i);
+
+        if(lang == "NAR")
+        {
+          printf("Avoiding audio description stream: %d\n", i + 1);
+        }
+        else
+        {
+          printf("Selecting audio stream: %d\n", i + 1);
+          m_audio_index_use = i + 1; // variable expects natural numbers
+          break;
+        }
+      }
+    }
+  }
+
   m_has_video     = m_omx_reader.VideoStreamCount();
   m_has_audio     = m_audio_index_use < 0 ? false : m_omx_reader.AudioStreamCount();
   m_has_subtitle  = !is_model_pi4() && !is_fkms_active() &&

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -970,7 +970,7 @@ int main(int argc, char *argv[])
 
   DISPLAY_TEXT_LONG("Loading...");
 
-  if(!m_has_external_subtitles && !filename_is_URL)
+  if(m_osd && !m_has_external_subtitles && !filename_is_URL)
   {
     auto subtitles_path = m_filename.substr(0, m_filename.find_last_of(".")) +
                           ".srt";

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1138,7 +1138,7 @@ int main(int argc, char *argv[])
       m_player_subtitles.SetUseExternalSubtitles(false);
     }
 
-    if(m_subtitle_index == -1 && !m_has_external_subtitles)
+    if(m_subtitle_index == -1)
       m_player_subtitles.SetVisible(false);
   }
 

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -80,6 +80,7 @@ long              m_Amplification       = 0;
 bool              m_NativeDeinterlace   = false;
 bool              m_HWDecode            = false;
 bool              m_osd                 = true;
+bool              m_show_subtitles      = true;
 bool              m_no_keys             = false;
 std::string       m_external_subtitles_path;
 bool              m_has_external_subtitles = false;
@@ -550,6 +551,7 @@ int main(int argc, char *argv[])
   const int key_config_opt  = 0x10d;
   const int amp_opt         = 0x10e;
   const int no_osd_opt      = 0x202;
+  const int hide_subtitles_opt= 0x214;
   const int orientation_opt = 0x204;
   const int fps_opt         = 0x208;
   const int live_opt        = 0x205;
@@ -617,6 +619,7 @@ int main(int argc, char *argv[])
     { "no-boost-on-downmix", no_argument, NULL,          no_boost_on_downmix_opt },
     { "key-config",   required_argument,  NULL,          key_config_opt },
     { "no-osd",       no_argument,        NULL,          no_osd_opt },
+    { "hide-subtitles", no_argument,      NULL,          hide_subtitles_opt },
     { "no-keys",      no_argument,        NULL,          no_keys_opt },
     { "orientation",  required_argument,  NULL,          orientation_opt },
     { "fps",          required_argument,  NULL,          fps_opt },
@@ -761,6 +764,9 @@ int main(int argc, char *argv[])
         break;
       case no_osd_opt:
         m_osd = false;
+        break;
+     case hide_subtitles_opt:
+        m_show_subtitles = false;
         break;
       case no_keys_opt:
         m_no_keys = true;
@@ -1138,7 +1144,7 @@ int main(int argc, char *argv[])
       m_player_subtitles.SetUseExternalSubtitles(false);
     }
 
-    if(m_subtitle_index == -1 && !m_has_external_subtitles)
+   if(!m_show_subtitles || (m_subtitle_index == -1 && !m_has_external_subtitles))
       m_player_subtitles.SetVisible(false);
   }
 
@@ -1205,6 +1211,7 @@ int main(int argc, char *argv[])
      case KeyConfig::ACTION_CHANGE_FILE:
         FlushStreams(DVD_NOPTS_VALUE);
         m_omx_reader.Close();
+        m_show_subtitles = m_player_subtitles.GetVisible(); // current pref
         m_player_subtitles.Close();
         m_player_video.Close();
         m_player_audio.Close();


### PR DESCRIPTION
Subtitles are currently enabled by default if available. This patch hides them. They can still be toggled on and off as now, it just starts playing the file with the subtitles hidden.