### PR TITLE
Fix missing libva1 on Raspbian Buster

### DIFF
--- a/prepare-native-raspbian.sh
+++ b/prepare-native-raspbian.sh
@@ -15,7 +15,7 @@ if [ -z `which sudo` ] ; then
 fi
     
 echo "Checking dpkg database for missing packages"
-REQUIRED_PKGS="ca-certificates git-core binutils libasound2-dev libva1 libpcre3-dev libidn11-dev libboost-dev libfreetype6-dev libdbus-1-dev libssl1.0-dev libssh-dev libsmbclient-dev gcc g++ sed pkg-config"
+REQUIRED_PKGS="ca-certificates git-core binutils libasound2-dev libva2 libpcre3-dev libidn11-dev libboost-dev libfreetype6-dev libdbus-1-dev libssl1.0-dev libssh-dev libsmbclient-dev gcc g++ sed pkg-config"
 MISSING_PKGS=""
 for pkg in $REQUIRED_PKGS
 do


### PR DESCRIPTION
Fixes #731.

If you have additional problems building such as missing libavutil or otherwise failing to build ffmpeg, so the comments in that ticket.