### PR TITLE
Fix omxplayer hanging, due to HW decoder swallowing all input buffers, and never returning them

### DIFF
--- a/OMXPlayerVideo.cpp
+++ b/OMXPlayerVideo.cpp
@@ -211,10 +211,19 @@ bool OMXPlayerVideo::Decode(OMXPacket *pkt)
   if(pts != DVD_NOPTS_VALUE)
     m_iCurrentPts = pts;
 
+  size_t i = 0;
   while((int) m_decoder->GetFreeSpace() < pkt->size)
   {
     OMXClock::OMXSleep(10);
     if(m_flush_requested) return true;
+    // Timeout after 1000 ms, and exit player to avoid freeze: https://github.com/popcornmix/omxplayer/issues/301
+    if (i >= 100) {
+      CLog::Log(LOGERROR, "OMXPlayerVideo::Decode timeout\n");
+      printf("OMXPlayerVideo::Decode timeout\n");
+      m_bAbort = true; //TODO: Test if exits program
+      return true;
+    }
+    i++;
   }
 
   CLog::Log(LOGINFO, "CDVDPlayerVideo::Decode dts:%.0f pts:%.0f cur:%.0f, size:%d", pkt->dts, pkt->pts, m_iCurrentPts, pkt->size);
@@ -397,5 +406,9 @@ bool OMXPlayerVideo::IsEOS()
   if(!m_decoder)
     return false;
   return m_packets.empty() && (!m_decoder || m_decoder->IsEOS());
+}
+
+bool OMXPlayerVideo::hasAborted() {
+  return m_bAbort;
 }
 

--- a/OMXPlayerVideo.h
+++ b/OMXPlayerVideo.h
@@ -100,6 +100,6 @@ public:
   void SetLayer(int layer);
   void SetVideoRect(const CRect& SrcRect, const CRect& DestRect);
   void SetVideoRect(int aspectMode);
-
+  bool hasAborted();
 };
 #endif

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -1796,8 +1796,10 @@ int main(int argc, char *argv[])
       }
       if(m_player_video.AddPacket(m_omx_pkt))
         m_omx_pkt = NULL;
-      else
-        OMXClock::OMXSleep(10);
+      else if (m_player_video.hasAborted()) {
+        goto do_exit;
+      } else
+          OMXClock::OMXSleep(10);
     }
     else if(m_has_audio && m_omx_pkt && !TRICKPLAY(m_av_clock->OMXPlaySpeed()) && m_omx_pkt->codec_type == AVMEDIA_TYPE_AUDIO)
     {


### PR DESCRIPTION
Fixes #301 

When the omxplayer is playing from an RTP stream and the stream changes a property of the video (framerate, bitrate, resolution), the omxplayer will continue feeding the stream into the HW decoder, and the HW decoder will simply swallow all the input buffers, and never call the COMXCoreComponent::DecoderEmptyBufferDoneCallback.
This behaviour results in the video output being frozen on the monitor, and the omxplayer will hang in the OMXPlayerVideo::Decode while loop forever.

The fix is to simply create a timeout in the while loop and after x seconds, set the m_bAbort flag, read the flag in the main loop, and go to do_exit.