### PR TITLE
Add audio destinations for "hdmi0" and "hdmi1"

### DIFF
--- a/OMXAudio.cpp
+++ b/OMXAudio.cpp
@@ -107,7 +107,10 @@ bool COMXAudio::PortSettingsChanged()
     if(!m_omx_render_analog.Initialize("OMX.broadcom.audio_render", OMX_IndexParamAudioInit))
       return false;
   }
-  if (m_config.device == "omx:both" || m_config.device == "omx:hdmi")
+  if (m_config.device == "omx:both" ||
+      m_config.device == "omx:hdmi" ||
+      m_config.device == "omx:hdmi0" ||
+      m_config.device == "omx:hdmi1")
   {
     if(!m_omx_render_hdmi.Initialize("OMX.broadcom.audio_render", OMX_IndexParamAudioInit))
       return false;
@@ -263,7 +266,10 @@ bool COMXAudio::PortSettingsChanged()
 
     OMX_CONFIG_BRCMAUDIODESTINATIONTYPE audioDest;
     OMX_INIT_STRUCTURE(audioDest);
-    strncpy((char *)audioDest.sName, "hdmi", strlen("hdmi"));
+    if (m_config.device == "omx:both")
+      strncpy((char *)audioDest.sName, "hdmi", strlen("hdmi"));
+    else
+      strncpy((char *)audioDest.sName, &m_config.device[4], strlen(m_config.device) - 4);
     omx_err = m_omx_render_hdmi.SetConfig(OMX_IndexConfigBrcmAudioDestination, &audioDest);
     if (omx_err != OMX_ErrorNone)
     {

--- a/omxplayer.cpp
+++ b/omxplayer.cpp
@@ -721,10 +721,14 @@ int main(int argc, char *argv[])
             m_config_audio.subdevice = "";
           }
         }
-        if(m_config_audio.device != "local" && m_config_audio.device != "hdmi" && m_config_audio.device != "both" &&
+        if(m_config_audio.device != "local" &&
+           m_config_audio.device != "hdmi" &&
+           m_config_audio.device != "hdmi0" &&
+           m_config_audio.device != "hdmi1" &&
+           m_config_audio.device != "both" &&
            m_config_audio.device != "alsa")
         {
-          printf("Bad argument for -%c: Output device must be `local', `hdmi', `both' or `alsa'\n", c);
+          printf("Bad argument for -%c: Output device must be `local', `hdmi', `hdmi0', `hdmi1', `both' or `alsa'\n", c);
           return EXIT_FAILURE;
         }
         m_config_audio.device = "omx:" + m_config_audio.device;


### PR DESCRIPTION
Allows the audio to be routed out of either HDMI port on a Pi4.